### PR TITLE
chore: add Claude Code dev-container for in-place dev on UNRAID

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ frontend/public/opencv/
 .pytest_cache/
 test_documents/
 .gstack/
+.claude-dev-home/

--- a/Dockerfile.claude
+++ b/Dockerfile.claude
@@ -9,15 +9,30 @@
 
 FROM node:20-bookworm
 
-# git/ripgrep for the CLI; docker.io provides ONLY the Docker *client*, which
-# drives the host daemon through the mounted /var/run/docker.sock so Claude can
-# rebuild/restart the app container. Remove docker.io if you'd rather rebuild by hand.
+# Dev tools for the Claude Code CLI.
 RUN apt-get update && apt-get install -y --no-install-recommends \
       git \
       ripgrep \
       less \
       ca-certificates \
-      docker.io \
+      curl \
+    && rm -rf /var/lib/apt/lists/*
+
+# Docker CLI + Compose v2 plugin ONLY (no daemon) from Docker's official repo.
+# These drive the *host* daemon via the mounted /var/run/docker.sock so Claude can
+# rebuild/restart the app with `docker compose up -d --build`. docker-ce-cli pulls
+# no dockerd; the compose/buildx plugins are what make `docker compose` available
+# (the Debian `docker.io` package does not ship the Compose v2 plugin).
+RUN install -m 0755 -d /etc/apt/keyrings \
+    && curl -fsSL https://download.docker.com/linux/debian/gpg -o /etc/apt/keyrings/docker.asc \
+    && chmod a+r /etc/apt/keyrings/docker.asc \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/debian bookworm stable" \
+       > /etc/apt/sources.list.d/docker.list \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends \
+         docker-ce-cli \
+         docker-compose-plugin \
+         docker-buildx-plugin \
     && rm -rf /var/lib/apt/lists/*
 
 RUN npm install -g @anthropic-ai/claude-code

--- a/Dockerfile.claude
+++ b/Dockerfile.claude
@@ -22,6 +22,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 RUN npm install -g @anthropic-ai/claude-code
 
+# The repo is bind-mounted and owned by the host user (e.g. UNRAID's nobody:users,
+# 99:100), while this container runs as root. Without this, git 2.39 refuses to
+# operate on it with "fatal: detected dubious ownership", which breaks Claude Code.
+RUN git config --system --add safe.directory '*'
+
 WORKDIR /workspace
 
 # Keep the container alive; you interact via `docker exec -it claude-dev claude`.

--- a/Dockerfile.claude
+++ b/Dockerfile.claude
@@ -1,0 +1,28 @@
+# Claude Code dev-container for developing Receiptory in place on a NAS (e.g. UNRAID).
+#
+# This is NOT the application image (that's ./Dockerfile). It's a lightweight
+# sidecar that carries the Claude Code CLI plus a few dev tools, and bind-mounts
+# the repo so you can edit/build/fix the app without installing anything on the
+# UNRAID host (whose root filesystem is reset on every reboot).
+#
+# Build & run: see docs/claude-code-on-unraid.md or docker-compose.claude.yml.
+
+FROM node:20-bookworm
+
+# git/ripgrep for the CLI; docker.io provides ONLY the Docker *client*, which
+# drives the host daemon through the mounted /var/run/docker.sock so Claude can
+# rebuild/restart the app container. Remove docker.io if you'd rather rebuild by hand.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      git \
+      ripgrep \
+      less \
+      ca-certificates \
+      docker.io \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN npm install -g @anthropic-ai/claude-code
+
+WORKDIR /workspace
+
+# Keep the container alive; you interact via `docker exec -it claude-dev claude`.
+CMD ["sleep", "infinity"]

--- a/docker-compose.claude.yml
+++ b/docker-compose.claude.yml
@@ -17,13 +17,14 @@ services:
       context: .
       dockerfile: Dockerfile.claude
     container_name: claude-dev
-    # The repo is mounted at the SAME absolute path it has on the host (${PWD}).
+    # The repo is mounted at the SAME absolute path it has on the host.
     # This matters: when Claude rebuilds the app with `docker compose up -d --build`,
     # the CLI runs in this container but the host daemon (via the mounted socket)
     # resolves the app's bind mounts (e.g. ./data) against the HOST filesystem.
     # Matching the path on both sides keeps those mounts pointing at the real
     # /mnt/user/appdata/Receiptory/data instead of a stray empty dir.
-    working_dir: ${PWD}
+    # Override RECEIPTORY_DIR (env or .env) if your repo lives elsewhere.
+    working_dir: ${RECEIPTORY_DIR:-/mnt/user/appdata/Receiptory}
     environment:
       # $HOME points at a bind-mounted dir so ~/.claude and ~/.claude.json persist.
       - HOME=/home/dev
@@ -31,7 +32,7 @@ services:
       # - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}
     volumes:
       # The repo, mounted at its real host path (see working_dir note above).
-      - ${PWD}:${PWD}
+      - ${RECEIPTORY_DIR:-/mnt/user/appdata/Receiptory}:${RECEIPTORY_DIR:-/mnt/user/appdata/Receiptory}
       # Persisted Claude config/auth (kept out of the repo; see .gitignore entry).
       - ./.claude-dev-home:/home/dev
       # Lets Claude rebuild/restart the app via `docker compose up -d --build`.

--- a/docker-compose.claude.yml
+++ b/docker-compose.claude.yml
@@ -6,7 +6,7 @@
 #   docker exec -it claude-dev claude          # start an interactive session
 #
 # First run: authenticate once with /login (paste the code from the printed URL),
-# or set ANTHROPIC_API_KEY below. Auth is persisted under ./ .claude-dev-home
+# or set ANTHROPIC_API_KEY below. Auth is persisted under ./.claude-dev-home
 # (mounted as $HOME) so it survives container and host restarts.
 #
 # Tear down with:  docker compose -f docker-compose.claude.yml down
@@ -17,15 +17,21 @@ services:
       context: .
       dockerfile: Dockerfile.claude
     container_name: claude-dev
-    working_dir: /workspace
+    # The repo is mounted at the SAME absolute path it has on the host (${PWD}).
+    # This matters: when Claude rebuilds the app with `docker compose up -d --build`,
+    # the CLI runs in this container but the host daemon (via the mounted socket)
+    # resolves the app's bind mounts (e.g. ./data) against the HOST filesystem.
+    # Matching the path on both sides keeps those mounts pointing at the real
+    # /mnt/user/appdata/Receiptory/data instead of a stray empty dir.
+    working_dir: ${PWD}
     environment:
       # $HOME points at a bind-mounted dir so ~/.claude and ~/.claude.json persist.
       - HOME=/home/dev
       # Optional: uncomment to auth via API key instead of interactive /login.
       # - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}
     volumes:
-      # The repo itself — Claude edits these files in place.
-      - .:/workspace
+      # The repo, mounted at its real host path (see working_dir note above).
+      - ${PWD}:${PWD}
       # Persisted Claude config/auth (kept out of the repo; see .gitignore entry).
       - ./.claude-dev-home:/home/dev
       # Lets Claude rebuild/restart the app via `docker compose up -d --build`.

--- a/docker-compose.claude.yml
+++ b/docker-compose.claude.yml
@@ -1,0 +1,37 @@
+# Claude Code dev-container for developing Receiptory in place on UNRAID.
+#
+# Usage (from the repo dir on the NAS, e.g. /mnt/user/appdata/Receiptory):
+#
+#   docker compose -f docker-compose.claude.yml up -d --build
+#   docker exec -it claude-dev claude          # start an interactive session
+#
+# First run: authenticate once with /login (paste the code from the printed URL),
+# or set ANTHROPIC_API_KEY below. Auth is persisted under ./ .claude-dev-home
+# (mounted as $HOME) so it survives container and host restarts.
+#
+# Tear down with:  docker compose -f docker-compose.claude.yml down
+
+services:
+  claude-dev:
+    build:
+      context: .
+      dockerfile: Dockerfile.claude
+    container_name: claude-dev
+    working_dir: /workspace
+    environment:
+      # $HOME points at a bind-mounted dir so ~/.claude and ~/.claude.json persist.
+      - HOME=/home/dev
+      # Optional: uncomment to auth via API key instead of interactive /login.
+      # - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}
+    volumes:
+      # The repo itself — Claude edits these files in place.
+      - .:/workspace
+      # Persisted Claude config/auth (kept out of the repo; see .gitignore entry).
+      - ./.claude-dev-home:/home/dev
+      # Lets Claude rebuild/restart the app via `docker compose up -d --build`.
+      # SECURITY: this grants root-equivalent control of the host Docker daemon.
+      # Comment it out if you prefer to rebuild the app manually.
+      - /var/run/docker.sock:/var/run/docker.sock
+    # Keep it running so you can `docker exec` in whenever you want to work.
+    command: ["sleep", "infinity"]
+    restart: unless-stopped

--- a/docs/claude-code-on-unraid.md
+++ b/docs/claude-code-on-unraid.md
@@ -46,13 +46,21 @@ and it survives container and host restarts. That directory is git-ignored.
 
 ## The dev loop
 
-Claude edits the live files under `/workspace` (= the repo). To see changes in the
-running app, rebuild and restart the application container — Claude can do this
-itself via the mounted Docker socket:
+Claude edits the live repo files in place. To see changes in the running app,
+rebuild and restart the application container — Claude can do this itself via the
+mounted Docker socket:
 
 ```bash
 docker compose up -d --build      # uses ./docker-compose.yml + ./Dockerfile
 ```
+
+This works because the repo is mounted at the **same absolute path** inside the
+sidecar as it has on the host (via `${PWD}` in `docker-compose.claude.yml`). The
+Docker CLI runs in the sidecar, but the host daemon resolves the app's bind mounts
+(e.g. `./data`) against the host filesystem — matching paths keeps `./data`
+pointing at the real `/mnt/user/appdata/Receiptory/data` instead of a stray empty
+directory. (If you launch the sidecar from a different directory, launch it from
+the repo root so `${PWD}` is correct.)
 
 This reuses the app's real image build (backend + frontend), so the dev container
 doesn't need Python/uv/npm. For tighter loops (running `pytest`, hot reload) you

--- a/docs/claude-code-on-unraid.md
+++ b/docs/claude-code-on-unraid.md
@@ -16,7 +16,8 @@ the same for Claude Code.
 ## What's here
 
 - **`Dockerfile.claude`** — a lightweight `node:20` image with the Claude Code CLI,
-  `git`, `ripgrep`, and the Docker *client* (to drive the host daemon).
+  `git`, `ripgrep`, and the Docker *client* + Compose v2 plugin (client-only, no
+  daemon; drives the host daemon via the mounted socket).
 - **`docker-compose.claude.yml`** — runs that image as a `claude-dev` container,
   bind-mounting the repo and persisting Claude's auth.
 
@@ -55,12 +56,13 @@ docker compose up -d --build      # uses ./docker-compose.yml + ./Dockerfile
 ```
 
 This works because the repo is mounted at the **same absolute path** inside the
-sidecar as it has on the host (via `${PWD}` in `docker-compose.claude.yml`). The
-Docker CLI runs in the sidecar, but the host daemon resolves the app's bind mounts
-(e.g. `./data`) against the host filesystem — matching paths keeps `./data`
-pointing at the real `/mnt/user/appdata/Receiptory/data` instead of a stray empty
-directory. (If you launch the sidecar from a different directory, launch it from
-the repo root so `${PWD}` is correct.)
+sidecar as it has on the host (`RECEIPTORY_DIR`, defaulting to
+`/mnt/user/appdata/Receiptory` in `docker-compose.claude.yml`). The Docker CLI
+runs in the sidecar, but the host daemon resolves the app's bind mounts (e.g.
+`./data`) against the host filesystem — matching paths keeps `./data` pointing at
+the real `/mnt/user/appdata/Receiptory/data` instead of a stray empty directory.
+If your repo lives elsewhere, set `RECEIPTORY_DIR` (in the environment or a `.env`
+file next to the compose file) to its absolute host path.
 
 This reuses the app's real image build (backend + frontend), so the dev container
 doesn't need Python/uv/npm. For tighter loops (running `pytest`, hot reload) you

--- a/docs/claude-code-on-unraid.md
+++ b/docs/claude-code-on-unraid.md
@@ -1,0 +1,81 @@
+# Developing Receiptory in place with Claude Code (UNRAID / NAS)
+
+This repo is deployed on an UNRAID NAS under `/mnt/user/appdata/Receiptory` and
+runs as a Docker container. This guide sets up **Claude Code as its own small
+container** so you can edit and fix the app in place without installing anything
+on the UNRAID host.
+
+## Why not install Claude Code on the UNRAID host
+
+UNRAID boots its OS into RAM from the USB flash drive; the root filesystem is
+rebuilt on every reboot. Anything you `npm install -g` on the host (Node, Claude
+Code) disappears on restart and clutters the appliance. The UNRAID-native pattern
+is: run everything in a container, keep all state in `/mnt/user/appdata`. We do
+the same for Claude Code.
+
+## What's here
+
+- **`Dockerfile.claude`** — a lightweight `node:20` image with the Claude Code CLI,
+  `git`, `ripgrep`, and the Docker *client* (to drive the host daemon).
+- **`docker-compose.claude.yml`** — runs that image as a `claude-dev` container,
+  bind-mounting the repo and persisting Claude's auth.
+
+## Setup
+
+From the repo directory on the NAS (`/mnt/user/appdata/Receiptory`):
+
+```bash
+docker compose -f docker-compose.claude.yml up -d --build
+```
+
+Start an interactive session (or use the container's `>_` console in the UNRAID
+Docker tab):
+
+```bash
+docker exec -it claude-dev claude
+```
+
+On first run, authenticate once:
+
+- **Subscription:** run `/login` inside Claude and paste the code from the printed
+  URL (works fine on a headless NAS), **or**
+- **API key:** uncomment `ANTHROPIC_API_KEY` in `docker-compose.claude.yml`.
+
+Auth is stored under `./.claude-dev-home` (mounted as `$HOME`), so you log in once
+and it survives container and host restarts. That directory is git-ignored.
+
+## The dev loop
+
+Claude edits the live files under `/workspace` (= the repo). To see changes in the
+running app, rebuild and restart the application container — Claude can do this
+itself via the mounted Docker socket:
+
+```bash
+docker compose up -d --build      # uses ./docker-compose.yml + ./Dockerfile
+```
+
+This reuses the app's real image build (backend + frontend), so the dev container
+doesn't need Python/uv/npm. For tighter loops (running `pytest`, hot reload) you
+can instead install `uv` and the frontend deps into the dev container and run the
+dev servers per the root `CLAUDE.md`.
+
+## Notes & cautions
+
+- **Docker socket = host root.** Mounting `/var/run/docker.sock` gives the dev
+  container root-equivalent control of every container on the host. Fine for a
+  trusted homelab LAN; comment it out in `docker-compose.claude.yml` if you'd
+  rather rebuild the app manually.
+- **Work on a branch.** You're editing the live deployed copy. Use
+  `git switch -c fix/...`, commit, and push to GitHub before rebuilding so a bad
+  edit can't strand the running app.
+- **Secrets.** `.env` (your LLM API key) is git-ignored — keep it that way.
+- **Permissions.** Files Claude writes may be root-owned. If the app runs as
+  `nobody:users`, run `chown -R 99:100 .` afterward, or give the dev container a
+  matching UID/GID.
+- **Back up `appdata`** (CA Backup plugin) before large changes.
+
+## Tear down
+
+```bash
+docker compose -f docker-compose.claude.yml down
+```


### PR DESCRIPTION
Adds a lightweight sidecar container carrying the Claude Code CLI so Receiptory can be developed/fixed **in place** on the UNRAID NAS without installing Node or Claude Code on the host (whose root filesystem resets on reboot).

## Contents
- **`Dockerfile.claude`** — `node:20` + Claude Code CLI, `git`, `ripgrep`, Docker client
- **`docker-compose.claude.yml`** — runs a `claude-dev` sidecar: bind-mounts the repo, persists auth via a mounted `$HOME`, mounts `docker.sock` so Claude can rebuild the app image
- **`docs/claude-code-on-unraid.md`** — setup, dev loop, and security notes
- **`.gitignore`** — ignores the persisted `.claude-dev-home/` auth dir

## Usage on the NAS
```bash
cd /mnt/user/appdata/Receiptory
docker compose -f docker-compose.claude.yml up -d --build
docker exec -it claude-dev claude
```

## Notes
- Does not touch the application image or runtime; purely additive tooling.
- `docker.sock` mount grants host-root-equivalent Docker control — documented as optional in the compose file and docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)