### PR TITLE
feat(export): add date_basis selector — ingestion vs issue date

### DIFF
--- a/backend/api/export.py
+++ b/backend/api/export.py
@@ -45,23 +45,29 @@ def export_documents(body: ExportRequest, request: Request, username: str = Depe
     if not body.document_ids and body.preset == "since_last_export":
         conditions.append("d.last_exported_date IS NULL")
     elif body.preset == "month" and body.month:
+        try:
+            month_dt = datetime.strptime(body.month, "%Y-%m")
+        except ValueError:
+            raise HTTPException(status_code=422, detail="month must be in YYYY-MM format")
+        if month_dt.month == 12:
+            next_month_dt = month_dt.replace(year=month_dt.year + 1, month=1)
+        else:
+            next_month_dt = month_dt.replace(month=month_dt.month + 1)
         conditions.append(f"{date_col} >= ?")
         conditions.append(f"{date_col} < ?")
-        year, month = body.month.split("-")
-        next_month = int(month) + 1
-        next_year = int(year)
-        if next_month > 12:
-            next_month = 1
-            next_year += 1
-        params.extend([f"{year}-{month}-01", f"{next_year:04d}-{next_month:02d}-01"])
-    elif body.preset == "full_year" and body.year:
+        params.extend([month_dt.strftime("%Y-%m-01"), next_month_dt.strftime("%Y-%m-01")])
+    elif body.preset == "full_year" and body.year is not None:
         conditions.append(f"{date_col} >= ?")
         conditions.append(f"{date_col} < ?")
-        params.extend([f"{body.year}-01-01", f"{body.year + 1}-01-01"])
+        params.extend([f"{body.year:04d}-01-01", f"{body.year + 1:04d}-01-01"])
     else:
         if body.date_from:
+            try:
+                date_from_dt = datetime.strptime(body.date_from, "%Y-%m-%d")
+            except ValueError:
+                raise HTTPException(status_code=422, detail="date_from must be in YYYY-MM-DD format")
             conditions.append(f"{date_col} >= ?")
-            params.append(body.date_from)
+            params.append(date_from_dt.strftime("%Y-%m-%d"))
         if body.date_to:
             try:
                 dt = datetime.strptime(body.date_to, "%Y-%m-%d")
@@ -75,7 +81,7 @@ def export_documents(body: ExportRequest, request: Request, username: str = Depe
                 params.append(next_day)
             else:
                 conditions.append(f"{date_col} <= ?")
-                params.append(body.date_to)
+                params.append(dt.strftime("%Y-%m-%d"))
 
     if body.status:
         conditions.append("d.status = ?")

--- a/backend/api/export.py
+++ b/backend/api/export.py
@@ -3,8 +3,8 @@ import io
 import os
 import zipfile
 import logging
-from datetime import datetime, timezone
-from fastapi import APIRouter, Depends, Request
+from datetime import datetime, timedelta, timezone
+from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import StreamingResponse
 
 from backend.auth import require_auth
@@ -40,11 +40,13 @@ def export_documents(body: ExportRequest, request: Request, username: str = Depe
     else:
         conditions.append("d.status = 'processed'")
 
+    date_col = "d.submission_date" if body.date_basis == "ingestion" else "d.receipt_date"
+
     if not body.document_ids and body.preset == "since_last_export":
         conditions.append("d.last_exported_date IS NULL")
     elif body.preset == "month" and body.month:
-        conditions.append("d.receipt_date >= ?")
-        conditions.append("d.receipt_date < ?")
+        conditions.append(f"{date_col} >= ?")
+        conditions.append(f"{date_col} < ?")
         year, month = body.month.split("-")
         next_month = int(month) + 1
         next_year = int(year)
@@ -53,16 +55,27 @@ def export_documents(body: ExportRequest, request: Request, username: str = Depe
             next_year += 1
         params.extend([f"{year}-{month}-01", f"{next_year:04d}-{next_month:02d}-01"])
     elif body.preset == "full_year" and body.year:
-        conditions.append("d.receipt_date >= ?")
-        conditions.append("d.receipt_date < ?")
+        conditions.append(f"{date_col} >= ?")
+        conditions.append(f"{date_col} < ?")
         params.extend([f"{body.year}-01-01", f"{body.year + 1}-01-01"])
     else:
         if body.date_from:
-            conditions.append("d.receipt_date >= ?")
+            conditions.append(f"{date_col} >= ?")
             params.append(body.date_from)
         if body.date_to:
-            conditions.append("d.receipt_date <= ?")
-            params.append(body.date_to)
+            try:
+                dt = datetime.strptime(body.date_to, "%Y-%m-%d")
+            except ValueError:
+                raise HTTPException(status_code=422, detail="date_to must be in YYYY-MM-DD format")
+            if body.date_basis == "ingestion":
+                # submission_date is a full ISO timestamp; use exclusive upper bound
+                # to include all documents ingested up to end-of-day UTC on date_to
+                next_day = (dt + timedelta(days=1)).strftime("%Y-%m-%d")
+                conditions.append(f"{date_col} < ?")
+                params.append(next_day)
+            else:
+                conditions.append(f"{date_col} <= ?")
+                params.append(body.date_to)
 
     if body.status:
         conditions.append("d.status = ?")
@@ -85,7 +98,7 @@ def export_documents(body: ExportRequest, request: Request, username: str = Depe
                 FROM documents d
                 LEFT JOIN categories c ON d.category_id = c.id
                 WHERE {where}
-                ORDER BY d.receipt_date""",
+                ORDER BY {date_col}""",
             params,
         ).fetchall()
 

--- a/backend/models.py
+++ b/backend/models.py
@@ -162,7 +162,7 @@ class ExportRequest(BaseModel):
     date_from: str | None = None
     date_to: str | None = None
     month: str | None = None  # YYYY-MM
-    year: int | None = None
+    year: int | None = Field(None, ge=1900)
     status: str | None = None
     category_id: int | None = None
     document_type: str | None = None

--- a/backend/models.py
+++ b/backend/models.py
@@ -158,6 +158,7 @@ class DuplicateGroup(BaseModel):
 
 class ExportRequest(BaseModel):
     preset: str | None = None  # since_last_export, month, date_range, full_year
+    date_basis: Literal["ingestion", "receipt"] = "ingestion"
     date_from: str | None = None
     date_to: str | None = None
     month: str | None = None  # YYYY-MM

--- a/frontend/src/pages/ExportPage.tsx
+++ b/frontend/src/pages/ExportPage.tsx
@@ -8,6 +8,7 @@ export default function ExportPage() {
   const [ingestionTo, setIngestionTo] = useState("");
   const [receiptFrom, setReceiptFrom] = useState("");
   const [receiptTo, setReceiptTo] = useState("");
+  const [presetBasis, setPresetBasis] = useState<"ingestion" | "receipt">("ingestion");
   const [month, setMonth] = useState("");
   const [year, setYear] = useState(new Date().getFullYear().toString());
   const [exporting, setExporting] = useState(false);
@@ -34,19 +35,19 @@ export default function ExportPage() {
       icon: "history",
       label: "All since last export",
       sub: "All pending documents",
-      action: () => doExport({ preset: "since_last_export" }),
+      action: () => doExport({ preset: "since_last_export", date_basis: presetBasis }),
     },
     {
       icon: "calendar_today",
       label: "This Month",
       sub: month || new Date().toLocaleString("default", { month: "long", year: "numeric" }),
-      action: () => doExport({ preset: "month", month: month || new Date().toISOString().slice(0, 7) }),
+      action: () => doExport({ preset: "month", month: month || new Date().toISOString().slice(0, 7), date_basis: presetBasis }),
     },
     {
       icon: "calendar_month",
       label: "Full Year",
       sub: `FY ${year}`,
-      action: () => doExport({ preset: "full_year", year: parseInt(year) }),
+      action: () => { if (!year || isNaN(parseInt(year)) || parseInt(year) < 1900) return; doExport({ preset: "full_year", year: parseInt(year), date_basis: presetBasis }); },
     },
   ];
 
@@ -72,7 +73,27 @@ export default function ExportPage() {
 
           {/* Quick Presets */}
           <section className="bg-card rounded-xl shadow-[0_8px_32px_rgba(25,28,30,0.04)] p-6">
-            <h3 className="text-xs font-black uppercase text-muted-foreground tracking-[0.2em] mb-6">Quick Export Presets</h3>
+            <div className="flex items-center justify-between mb-6">
+              <h3 className="text-xs font-black uppercase text-muted-foreground tracking-[0.2em]">Quick Export Presets</h3>
+              <div className="flex gap-1 bg-muted rounded-lg p-1">
+                <button
+                  onClick={() => setPresetBasis("ingestion")}
+                  className={`px-3 py-1 rounded text-[11px] font-bold transition-colors ${
+                    presetBasis === "ingestion" ? "bg-card text-primary shadow-sm" : "text-muted-foreground hover:text-foreground"
+                  }`}
+                >
+                  By Upload Date
+                </button>
+                <button
+                  onClick={() => setPresetBasis("receipt")}
+                  className={`px-3 py-1 rounded text-[11px] font-bold transition-colors ${
+                    presetBasis === "receipt" ? "bg-card text-primary shadow-sm" : "text-muted-foreground hover:text-foreground"
+                  }`}
+                >
+                  By Issue Date
+                </button>
+              </div>
+            </div>
             <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
               {PRESETS.map((preset) => (
                 <button
@@ -107,7 +128,7 @@ export default function ExportPage() {
                   />
                   <button
                     disabled={exporting || !month}
-                    onClick={() => doExport({ preset: "month", month })}
+                    onClick={() => doExport({ preset: "month", month, date_basis: presetBasis })}
                     className="px-4 py-2 bg-primary text-white rounded-lg text-sm font-bold hover:opacity-90 disabled:opacity-40 disabled:cursor-not-allowed transition-opacity"
                   >
                     Export
@@ -128,8 +149,8 @@ export default function ExportPage() {
                     className="bg-muted border-none rounded-lg text-sm focus-visible:ring-primary/20 flex-1"
                   />
                   <button
-                    disabled={exporting}
-                    onClick={() => doExport({ preset: "full_year", year: parseInt(year) })}
+                    disabled={exporting || !year || isNaN(parseInt(year)) || parseInt(year) < 1900}
+                    onClick={() => doExport({ preset: "full_year", year: parseInt(year), date_basis: presetBasis })}
                     className="px-4 py-2 bg-primary text-white rounded-lg text-sm font-bold hover:opacity-90 disabled:opacity-40 disabled:cursor-not-allowed transition-opacity"
                   >
                     Export
@@ -231,7 +252,7 @@ export default function ExportPage() {
             </div>
             <button
               disabled={exporting}
-              onClick={() => doExport({ preset: "since_last_export" })}
+              onClick={() => doExport({ preset: "since_last_export", date_basis: presetBasis })}
               className="w-full md:w-auto px-8 py-3 bg-card text-primary rounded-lg font-black text-sm hover:bg-[#d1e4fb] disabled:opacity-40 disabled:cursor-not-allowed transition-colors flex items-center gap-2 justify-center"
             >
               {exporting ? (

--- a/frontend/src/pages/ExportPage.tsx
+++ b/frontend/src/pages/ExportPage.tsx
@@ -4,8 +4,10 @@ import { Label } from "@/components/ui/label";
 import { api } from "@/lib/api";
 
 export default function ExportPage() {
-  const [dateFrom, setDateFrom] = useState("");
-  const [dateTo, setDateTo] = useState("");
+  const [ingestionFrom, setIngestionFrom] = useState("");
+  const [ingestionTo, setIngestionTo] = useState("");
+  const [receiptFrom, setReceiptFrom] = useState("");
+  const [receiptTo, setReceiptTo] = useState("");
   const [month, setMonth] = useState("");
   const [year, setYear] = useState(new Date().getFullYear().toString());
   const [exporting, setExporting] = useState(false);
@@ -134,46 +136,86 @@ export default function ExportPage() {
                   </button>
                 </div>
               </div>
-
-              {/* Date range */}
-              <div>
-                <Label className="block text-[11px] font-bold text-muted-foreground uppercase mb-2">Date Range — From</Label>
-                <div className="bg-muted px-3 py-2 rounded-lg flex items-center justify-between">
-                  <Input
-                    type="date"
-                    value={dateFrom}
-                    onChange={(e) => setDateFrom(e.target.value)}
-                    className="bg-transparent border-none p-0 text-sm focus-visible:ring-0 text-foreground font-bold"
-                  />
-                </div>
-              </div>
-
-              <div>
-                <Label className="block text-[11px] font-bold text-muted-foreground uppercase mb-2">Date Range — To</Label>
-                <div className="bg-muted px-3 py-2 rounded-lg flex items-center justify-between">
-                  <Input
-                    type="date"
-                    value={dateTo}
-                    onChange={(e) => setDateTo(e.target.value)}
-                    className="bg-transparent border-none p-0 text-sm focus-visible:ring-0 text-foreground font-bold"
-                  />
-                </div>
-              </div>
             </div>
 
-            {/* Custom range export button */}
-            {(dateFrom || dateTo) && (
-              <div className="mt-6">
-                <button
-                  disabled={exporting || (!dateFrom && !dateTo)}
-                  onClick={() => doExport({ date_from: dateFrom, date_to: dateTo })}
-                  className="px-6 py-2.5 bg-primary text-white rounded-lg text-sm font-bold hover:opacity-90 disabled:opacity-40 disabled:cursor-not-allowed transition-opacity flex items-center gap-2"
-                >
-                  <span className="material-symbols-outlined text-sm">date_range</span>
-                  Export Date Range
-                </button>
+            {/* Date range — two independent columns by date type */}
+            <div className="mt-6 grid grid-cols-1 md:grid-cols-2 gap-x-12 gap-y-6">
+              {/* Ingestion date column */}
+              <div className="space-y-3">
+                <div className="flex items-center gap-2">
+                  <span className="material-symbols-outlined text-sm text-primary">upload</span>
+                  <Label className="text-[11px] font-bold text-muted-foreground uppercase tracking-wider">By Ingestion Date</Label>
+                </div>
+                <div className="space-y-2">
+                  <div className="bg-muted px-3 py-2 rounded-lg">
+                    <p className="text-[10px] text-muted-foreground mb-1">From</p>
+                    <Input
+                      type="date"
+                      value={ingestionFrom}
+                      onChange={(e) => setIngestionFrom(e.target.value)}
+                      className="bg-transparent border-none p-0 text-sm focus-visible:ring-0 text-foreground font-bold"
+                    />
+                  </div>
+                  <div className="bg-muted px-3 py-2 rounded-lg">
+                    <p className="text-[10px] text-muted-foreground mb-1">To</p>
+                    <Input
+                      type="date"
+                      value={ingestionTo}
+                      onChange={(e) => setIngestionTo(e.target.value)}
+                      className="bg-transparent border-none p-0 text-sm focus-visible:ring-0 text-foreground font-bold"
+                    />
+                  </div>
+                </div>
+                {(ingestionFrom || ingestionTo) && (
+                  <button
+                    disabled={exporting}
+                    onClick={() => doExport({ date_basis: "ingestion", date_from: ingestionFrom || undefined, date_to: ingestionTo || undefined })}
+                    className="px-4 py-2 bg-primary text-white rounded-lg text-sm font-bold hover:opacity-90 disabled:opacity-40 disabled:cursor-not-allowed transition-opacity flex items-center gap-2"
+                  >
+                    <span className="material-symbols-outlined text-sm">date_range</span>
+                    Export
+                  </button>
+                )}
               </div>
-            )}
+
+              {/* Receipt/issue date column */}
+              <div className="space-y-3">
+                <div className="flex items-center gap-2">
+                  <span className="material-symbols-outlined text-sm text-primary">receipt</span>
+                  <Label className="text-[11px] font-bold text-muted-foreground uppercase tracking-wider">By Issue Date</Label>
+                </div>
+                <div className="space-y-2">
+                  <div className="bg-muted px-3 py-2 rounded-lg">
+                    <p className="text-[10px] text-muted-foreground mb-1">From</p>
+                    <Input
+                      type="date"
+                      value={receiptFrom}
+                      onChange={(e) => setReceiptFrom(e.target.value)}
+                      className="bg-transparent border-none p-0 text-sm focus-visible:ring-0 text-foreground font-bold"
+                    />
+                  </div>
+                  <div className="bg-muted px-3 py-2 rounded-lg">
+                    <p className="text-[10px] text-muted-foreground mb-1">To</p>
+                    <Input
+                      type="date"
+                      value={receiptTo}
+                      onChange={(e) => setReceiptTo(e.target.value)}
+                      className="bg-transparent border-none p-0 text-sm focus-visible:ring-0 text-foreground font-bold"
+                    />
+                  </div>
+                </div>
+                {(receiptFrom || receiptTo) && (
+                  <button
+                    disabled={exporting}
+                    onClick={() => doExport({ date_basis: "receipt", date_from: receiptFrom || undefined, date_to: receiptTo || undefined })}
+                    className="px-4 py-2 bg-primary text-white rounded-lg text-sm font-bold hover:opacity-90 disabled:opacity-40 disabled:cursor-not-allowed transition-opacity flex items-center gap-2"
+                  >
+                    <span className="material-symbols-outlined text-sm">date_range</span>
+                    Export
+                  </button>
+                )}
+              </div>
+            </div>
           </section>
 
           {/* Generate Zip Banner */}

--- a/migrations/007_add_submission_date_index.sql
+++ b/migrations/007_add_submission_date_index.sql
@@ -1,0 +1,1 @@
+CREATE INDEX IF NOT EXISTS idx_documents_submission_date ON documents(submission_date);

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -226,3 +226,21 @@ def test_export_invalid_date_to(authed_client):
     """Malformed date_to returns 422, not 500."""
     resp = authed_client.post("/api/export", json={"date_basis": "ingestion", "date_from": "2026-01-01", "date_to": "not-a-date"})
     assert resp.status_code == 422
+
+
+def test_export_invalid_date_from(authed_client):
+    """Malformed date_from returns 422, not silent empty results."""
+    resp = authed_client.post("/api/export", json={"date_basis": "ingestion", "date_from": "not-a-date"})
+    assert resp.status_code == 422
+
+
+def test_export_invalid_month_format(authed_client):
+    """Malformed month returns 422, not 500."""
+    resp = authed_client.post("/api/export", json={"preset": "month", "month": "2026/07"})
+    assert resp.status_code == 422
+
+
+def test_export_month_single_digit(authed_client):
+    """month='2026-1' is accepted — strptime is lenient, strftime zero-pads output."""
+    resp = authed_client.post("/api/export", json={"preset": "month", "month": "2026-1"})
+    assert resp.status_code == 200

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -50,7 +50,8 @@ def docs_with_files(authed_client, db_path, tmp_data_dir, sample_pdf_path):
 
 
 def test_export_zip_structure(authed_client, docs_with_files):
-    resp = authed_client.post("/api/export", json={"date_from": "2026-01-01", "date_to": "2026-12-31"})
+    # Explicit date_basis="receipt" preserves original receipt-date semantics
+    resp = authed_client.post("/api/export", json={"date_basis": "receipt", "date_from": "2026-01-01", "date_to": "2026-12-31"})
     assert resp.status_code == 200
     assert resp.headers["content-type"] == "application/zip"
 
@@ -61,7 +62,7 @@ def test_export_zip_structure(authed_client, docs_with_files):
 
 
 def test_export_csv_content(authed_client, docs_with_files):
-    resp = authed_client.post("/api/export", json={"date_from": "2026-01-01", "date_to": "2026-12-31"})
+    resp = authed_client.post("/api/export", json={"date_basis": "receipt", "date_from": "2026-01-01", "date_to": "2026-12-31"})
     zf = zipfile.ZipFile(io.BytesIO(resp.content))
     csv_content = zf.read("metadata.csv").decode("utf-8")
     reader = csv.DictReader(io.StringIO(csv_content))
@@ -71,8 +72,157 @@ def test_export_csv_content(authed_client, docs_with_files):
 
 
 def test_export_updates_last_exported(authed_client, docs_with_files):
-    authed_client.post("/api/export", json={"date_from": "2026-01-01", "date_to": "2026-12-31"})
+    authed_client.post("/api/export", json={"date_basis": "receipt", "date_from": "2026-01-01", "date_to": "2026-12-31"})
     with get_connection() as conn:
         docs = conn.execute("SELECT last_exported_date FROM documents WHERE status = 'processed'").fetchall()
     for doc in docs:
         assert doc["last_exported_date"] is not None
+
+
+def _write_dummy_pdf(path: str) -> None:
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "wb") as f:
+        f.write(b"%PDF-1.4\n%%EOF\n")
+
+
+def test_export_ingestion_basis(authed_client, db_path, tmp_data_dir):
+    """Doc with submission_date in range but receipt_date out of range appears in ingestion export only."""
+    filed_dir = os.path.join(str(tmp_data_dir), "storage", "filed")
+
+    with get_connection() as conn:
+        conn.execute(
+            """INSERT INTO documents (original_filename, file_hash, file_size_bytes, status,
+               stored_filename, receipt_date, submission_date, vendor_name, total_amount, category_id, submission_channel)
+               VALUES ('ing.pdf', 'h3', 100, 'processed', '2026-03-01-ING-h3.pdf',
+               '2025-11-15', '2026-03-01T10:00:00Z', 'Ingested Vendor', 50.0, 4, 'web_upload')"""
+        )
+    _write_dummy_pdf(os.path.join(filed_dir, "2026-03-01-ING-h3.pdf"))
+
+    # Visible with ingestion basis (submission_date is in March 2026)
+    resp = authed_client.post("/api/export", json={"date_basis": "ingestion", "date_from": "2026-03-01", "date_to": "2026-03-31"})
+    assert resp.status_code == 200
+    zf = zipfile.ZipFile(io.BytesIO(resp.content))
+    csv_content = zf.read("metadata.csv").decode("utf-8")
+    rows = list(csv.DictReader(io.StringIO(csv_content)))
+    assert any(r["vendor_name"] == "Ingested Vendor" for r in rows)
+
+    # NOT visible with receipt basis (receipt_date is Nov 2025, outside March 2026)
+    resp2 = authed_client.post("/api/export", json={"date_basis": "receipt", "date_from": "2026-03-01", "date_to": "2026-03-31"})
+    assert resp2.status_code == 200
+    zf2 = zipfile.ZipFile(io.BytesIO(resp2.content))
+    csv2 = zf2.read("metadata.csv").decode("utf-8")
+    rows2 = list(csv.DictReader(io.StringIO(csv2)))
+    assert not any(r["vendor_name"] == "Ingested Vendor" for r in rows2)
+
+
+def test_export_receipt_basis(authed_client, db_path, tmp_data_dir):
+    """Doc with receipt_date in range but submission_date out of range appears in receipt export only."""
+    filed_dir = os.path.join(str(tmp_data_dir), "storage", "filed")
+
+    with get_connection() as conn:
+        conn.execute(
+            """INSERT INTO documents (original_filename, file_hash, file_size_bytes, status,
+               stored_filename, receipt_date, submission_date, vendor_name, total_amount, category_id, submission_channel)
+               VALUES ('rcpt.pdf', 'h4', 100, 'processed', '2026-04-01-RCPT-h4.pdf',
+               '2026-04-10', '2025-12-01T08:00:00Z', 'Receipt Vendor', 75.0, 4, 'web_upload')"""
+        )
+    _write_dummy_pdf(os.path.join(filed_dir, "2026-04-01-RCPT-h4.pdf"))
+
+    # Visible with receipt basis (receipt_date is April 2026)
+    resp = authed_client.post("/api/export", json={"date_basis": "receipt", "date_from": "2026-04-01", "date_to": "2026-04-30"})
+    assert resp.status_code == 200
+    rows = list(csv.DictReader(io.StringIO(zipfile.ZipFile(io.BytesIO(resp.content)).read("metadata.csv").decode())))
+    assert any(r["vendor_name"] == "Receipt Vendor" for r in rows)
+
+    # NOT visible with ingestion basis (submission_date is Dec 2025)
+    resp2 = authed_client.post("/api/export", json={"date_basis": "ingestion", "date_from": "2026-04-01", "date_to": "2026-04-30"})
+    assert resp2.status_code == 200
+    rows2 = list(csv.DictReader(io.StringIO(zipfile.ZipFile(io.BytesIO(resp2.content)).read("metadata.csv").decode())))
+    assert not any(r["vendor_name"] == "Receipt Vendor" for r in rows2)
+
+
+def test_export_null_receipt_date_ingestion(authed_client, db_path, tmp_data_dir):
+    """Doc with NULL receipt_date and a valid submission_date appears in ingestion export."""
+    filed_dir = os.path.join(str(tmp_data_dir), "storage", "filed")
+
+    with get_connection() as conn:
+        conn.execute(
+            """INSERT INTO documents (original_filename, file_hash, file_size_bytes, status,
+               stored_filename, receipt_date, submission_date, vendor_name, total_amount, category_id, submission_channel)
+               VALUES ('null_rcpt.pdf', 'h5', 100, 'processed', '2026-05-01-NULL-h5.pdf',
+               NULL, '2026-05-01T09:00:00Z', 'No Date Vendor', 25.0, 4, 'web_upload')"""
+        )
+    _write_dummy_pdf(os.path.join(filed_dir, "2026-05-01-NULL-h5.pdf"))
+
+    # Appears with ingestion basis despite NULL receipt_date
+    resp = authed_client.post("/api/export", json={"date_basis": "ingestion", "date_from": "2026-05-01", "date_to": "2026-05-31"})
+    assert resp.status_code == 200
+    rows = list(csv.DictReader(io.StringIO(zipfile.ZipFile(io.BytesIO(resp.content)).read("metadata.csv").decode())))
+    assert any(r["vendor_name"] == "No Date Vendor" for r in rows)
+
+    # Silently excluded with receipt basis (receipt_date IS NULL)
+    resp2 = authed_client.post("/api/export", json={"date_basis": "receipt", "date_from": "2026-05-01", "date_to": "2026-05-31"})
+    assert resp2.status_code == 200
+    rows2 = list(csv.DictReader(io.StringIO(zipfile.ZipFile(io.BytesIO(resp2.content)).read("metadata.csv").decode())))
+    assert not any(r["vendor_name"] == "No Date Vendor" for r in rows2)
+
+
+def test_export_date_to_boundary_ingestion(authed_client, db_path, tmp_data_dir):
+    """Doc ingested at 23:59:59 UTC on date_to day IS included (exclusive upper bound < next_day)."""
+    filed_dir = os.path.join(str(tmp_data_dir), "storage", "filed")
+
+    with get_connection() as conn:
+        conn.execute(
+            """INSERT INTO documents (original_filename, file_hash, file_size_bytes, status,
+               stored_filename, receipt_date, submission_date, vendor_name, total_amount, category_id, submission_channel)
+               VALUES ('late.pdf', 'h6', 100, 'processed', '2026-06-30-LATE-h6.pdf',
+               '2026-06-30', '2026-06-30T23:59:59Z', 'Late Vendor', 10.0, 4, 'web_upload')"""
+        )
+    _write_dummy_pdf(os.path.join(filed_dir, "2026-06-30-LATE-h6.pdf"))
+
+    # date_to="2026-06-30" with ingestion basis: uses < "2026-07-01", so 23:59:59 is included
+    resp = authed_client.post("/api/export", json={"date_basis": "ingestion", "date_from": "2026-06-01", "date_to": "2026-06-30"})
+    assert resp.status_code == 200
+    rows = list(csv.DictReader(io.StringIO(zipfile.ZipFile(io.BytesIO(resp.content)).read("metadata.csv").decode())))
+    assert any(r["vendor_name"] == "Late Vendor" for r in rows)
+
+
+def test_export_order_by_matches_basis(authed_client, db_path, tmp_data_dir):
+    """Rows are sorted by submission_date for ingestion basis, receipt_date for receipt basis."""
+    filed_dir = os.path.join(str(tmp_data_dir), "storage", "filed")
+
+    with get_connection() as conn:
+        # Doc A: ingested first, receipt date second
+        conn.execute(
+            """INSERT INTO documents (original_filename, file_hash, file_size_bytes, status,
+               stored_filename, receipt_date, submission_date, vendor_name, total_amount, category_id, submission_channel)
+               VALUES ('a.pdf', 'ha', 100, 'processed', '2026-07-01-A-ha.pdf',
+               '2026-07-10', '2026-07-01T08:00:00Z', 'Alpha', 10.0, 4, 'web_upload')"""
+        )
+        # Doc B: ingested second, receipt date first
+        conn.execute(
+            """INSERT INTO documents (original_filename, file_hash, file_size_bytes, status,
+               stored_filename, receipt_date, submission_date, vendor_name, total_amount, category_id, submission_channel)
+               VALUES ('b.pdf', 'hb', 100, 'processed', '2026-07-01-B-hb.pdf',
+               '2026-07-01', '2026-07-10T08:00:00Z', 'Beta', 20.0, 4, 'web_upload')"""
+        )
+    _write_dummy_pdf(os.path.join(filed_dir, "2026-07-01-A-ha.pdf"))
+    _write_dummy_pdf(os.path.join(filed_dir, "2026-07-01-B-hb.pdf"))
+
+    # Ingestion basis: Alpha (ingested July 1) before Beta (ingested July 10)
+    resp = authed_client.post("/api/export", json={"date_basis": "ingestion", "date_from": "2026-07-01", "date_to": "2026-07-31"})
+    rows = list(csv.DictReader(io.StringIO(zipfile.ZipFile(io.BytesIO(resp.content)).read("metadata.csv").decode())))
+    vendors_ingestion = [r["vendor_name"] for r in rows]
+    assert vendors_ingestion == ["Alpha", "Beta"]
+
+    # Receipt basis: Beta (receipt July 1) before Alpha (receipt July 10)
+    resp2 = authed_client.post("/api/export", json={"date_basis": "receipt", "date_from": "2026-07-01", "date_to": "2026-07-31"})
+    rows2 = list(csv.DictReader(io.StringIO(zipfile.ZipFile(io.BytesIO(resp2.content)).read("metadata.csv").decode())))
+    vendors_receipt = [r["vendor_name"] for r in rows2]
+    assert vendors_receipt == ["Beta", "Alpha"]
+
+
+def test_export_invalid_date_to(authed_client):
+    """Malformed date_to returns 422, not 500."""
+    resp = authed_client.post("/api/export", json={"date_basis": "ingestion", "date_from": "2026-01-01", "date_to": "not-a-date"})
+    assert resp.status_code == 422


### PR DESCRIPTION
## Summary

- Adds `date_basis: "ingestion" | "receipt"` (default `"ingestion"`) to `ExportRequest` so exports can be filtered by either upload date (`submission_date`) or the date printed on the receipt (`receipt_date`)
- Documents with `NULL receipt_date` (which silently disappeared under the old receipt-only behavior) are always reachable when using ingestion basis
- Uses an exclusive upper bound (`< next_day`) when filtering on `submission_date`, which is a full ISO timestamp, to correctly include documents ingested at any time on the boundary date
- Adds a `submission_date` index via migration 007 for query performance
- Replaces the single date-range section in the Export UI with two independent columns: **By Ingestion Date** and **By Issue Date**, each with its own From/To pickers and Export button

## Test plan

- [ ] All 9 export tests pass (`uv run pytest tests/test_export.py -v`)
- [ ] `test_export_ingestion_basis` — doc with receipt_date outside range appears via ingestion, not receipt
- [ ] `test_export_null_receipt_date_ingestion` — doc with NULL receipt_date appears via ingestion basis
- [ ] `test_export_date_to_boundary_ingestion` — doc ingested at 23:59:59 UTC on date_to IS included
- [ ] `test_export_order_by_matches_basis` — sort order matches chosen basis
- [ ] `test_export_invalid_date_to` — malformed date_to returns 422 not 500
- [ ] UI: each column's Export button appears only when at least one date is filled
- [ ] UI: Quick Presets (this month, full year, since last export) continue to work

🤖 Generated with [Claude Code](https://claude.com/claude-code)