### PR TITLE
fix(scanner): full-resolution capture + camera init fixes (#3, #4)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ frontend/public/opencv/
 test_documents/
 .gstack/
 .claude-dev-home/
+.claude/skills/gstack/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule ".claude/skills/gstack"]
-	path = .claude/skills/gstack
-	url = https://github.com/garrytan/gstack.git

--- a/frontend/src/components/scanner/CameraViewfinder.tsx
+++ b/frontend/src/components/scanner/CameraViewfinder.tsx
@@ -6,11 +6,15 @@ import { TemporalSmoother } from "@/lib/scanner/smoother";
 interface CameraViewfinderProps {
   detector: Detector;
   detectorParams: any;
-  onCapture: (imageData: ImageData, corners: Quad | null) => void;
+  onCapture: (imageData: ImageData, corners: Quad | null, detectionScale: number) => void;
   onAutoCapture?: () => void;
 }
 
-const DETECTION_SCALE = 0.4;
+// Live-detection input is downscaled for speed. We cap the long side at
+// DETECTION_MAX_DIM so a 4K preview doesn't quadruple the detector's workload;
+// BASE_DETECTION_SCALE is the ceiling applied to lower-resolution streams.
+const BASE_DETECTION_SCALE = 0.4;
+const DETECTION_MAX_DIM = 800;
 
 export default function CameraViewfinder({
   detector,
@@ -18,14 +22,20 @@ export default function CameraViewfinder({
   onCapture,
   onAutoCapture,
 }: CameraViewfinderProps) {
-  const { videoRef, error, ready } = useCamera();
+  const { videoRef, error, ready, capturePhoto } = useCamera();
   const overlayRef = useRef<HTMLCanvasElement>(null);
   const cornersRef = useRef<Quad | null>(null);
   const [documentDetected, setDocumentDetected] = useState(false);
+  const [capturing, setCapturing] = useState(false);
   const frameCount = useRef(0);
   const detecting = useRef(false);
   const smoother = useMemo(() => new TemporalSmoother(), []);
   const lastAutoCaptureRef = useRef(0);
+  const detScaleRef = useRef(BASE_DETECTION_SCALE);
+  // Synchronous guard against overlapping captures (takePhoto can take ~2s).
+  // A ref, not just `capturing`, so a rapid double-tap before the re-render
+  // can't slip a second call through a stale closure.
+  const capturingRef = useRef(false);
 
   useEffect(() => {
     if (!ready) return;
@@ -38,10 +48,16 @@ export default function CameraViewfinder({
     const tick = () => {
       frameCount.current++;
 
+      const detScale =
+        video.videoWidth > 0
+          ? Math.min(BASE_DETECTION_SCALE, DETECTION_MAX_DIM / Math.max(video.videoWidth, video.videoHeight))
+          : BASE_DETECTION_SCALE;
+      detScaleRef.current = detScale;
+
       if (frameCount.current % 5 === 0 && video.videoWidth > 0 && !detecting.current) {
         detecting.current = true;
-        offscreen.width = Math.round(video.videoWidth * DETECTION_SCALE);
-        offscreen.height = Math.round(video.videoHeight * DETECTION_SCALE);
+        offscreen.width = Math.round(video.videoWidth * detScale);
+        offscreen.height = Math.round(video.videoHeight * detScale);
         const ctx = offscreen.getContext("2d")!;
         ctx.drawImage(video, 0, 0, offscreen.width, offscreen.height);
         const imageData = ctx.getImageData(0, 0, offscreen.width, offscreen.height);
@@ -80,8 +96,8 @@ export default function CameraViewfinder({
 
         const corners = cornersRef.current;
         if (corners) {
-          const scaleX = overlay.width / (video.videoWidth * DETECTION_SCALE);
-          const scaleY = overlay.height / (video.videoHeight * DETECTION_SCALE);
+          const scaleX = overlay.width / (video.videoWidth * detScale);
+          const scaleY = overlay.height / (video.videoHeight * detScale);
           const pts = [corners.topLeft, corners.topRight, corners.bottomRight, corners.bottomLeft];
 
           ctx.beginPath();
@@ -115,17 +131,27 @@ export default function CameraViewfinder({
     return () => cancelAnimationFrame(animId);
   }, [ready, videoRef, detector, detectorParams, smoother, onAutoCapture]);
 
-  const handleCapture = useCallback(() => {
-    const video = videoRef.current;
-    if (!video || !ready) return;
-    const canvas = document.createElement("canvas");
-    canvas.width = video.videoWidth;
-    canvas.height = video.videoHeight;
-    const ctx = canvas.getContext("2d")!;
-    ctx.drawImage(video, 0, 0);
-    const imageData = ctx.getImageData(0, 0, canvas.width, canvas.height);
-    onCapture(imageData, cornersRef.current);
-  }, [videoRef, ready, onCapture]);
+  const handleCapture = useCallback(async () => {
+    if (capturingRef.current) return;
+    capturingRef.current = true;
+    setCapturing(true);
+    try {
+      const result = await capturePhoto();
+      if (!result) return;
+      if (result.source === "photo") {
+        // Full-resolution still: the viewfinder corners were detected against
+        // the preview stream (different resolution / field of view), so they
+        // don't apply. Pass null to make extractAndEnhance re-detect on this
+        // image.
+        onCapture(result.imageData, null, 1);
+      } else {
+        onCapture(result.imageData, cornersRef.current, detScaleRef.current);
+      }
+    } finally {
+      capturingRef.current = false;
+      setCapturing(false);
+    }
+  }, [capturePhoto, onCapture]);
 
   if (error) {
     return (
@@ -158,8 +184,8 @@ export default function CameraViewfinder({
       <div className="absolute bottom-8 left-0 right-0 flex justify-center">
         <button
           onClick={handleCapture}
-          disabled={!ready}
-          className={`w-20 h-20 rounded-full border-4 border-white flex items-center justify-center transition-all active:scale-90 ${
+          disabled={!ready || capturing}
+          className={`w-20 h-20 rounded-full border-4 border-white flex items-center justify-center transition-all active:scale-90 disabled:opacity-60 ${
             documentDetected ? "bg-[#006d37]/80" : "bg-white/20"
           }`}
         >

--- a/frontend/src/lib/opencv-loader.ts
+++ b/frontend/src/lib/opencv-loader.ts
@@ -43,8 +43,12 @@ export async function detectCorners(imageData: ImageData): Promise<any> {
 
 /**
  * Extract the document from a full-resolution capture.
- * Corners come from detectCorners() which ran on a 0.4x scaled frame,
- * so they need to be scaled up to match the full-res imageData.
+ * When `corners` are supplied, they were detected on a downscaled preview frame
+ * (see `detectionScale`, which varies with the stream resolution), so they are
+ * scaled up by 1/detectionScale to match the full-res imageData. When `corners`
+ * is null (e.g. a full-resolution still whose field of view differs from the
+ * preview), the document is re-detected on the image itself and `detectionScale`
+ * is ignored.
  */
 export async function extractAndEnhance(
   imageData: ImageData,
@@ -76,7 +80,11 @@ export async function extractAndEnhance(
     }
   }
 
-  // Fallback: run full detect+extract on the full-res frame
+  // Full detect+extract on the full-res frame. This is also the intended path
+  // for full-resolution stills (ImageCapture): callers pass corners=null so the
+  // document is re-detected here, because viewfinder corners were measured
+  // against the lower-res preview and don't map onto the still. Keep this branch
+  // doing a real detection — the photo capture path depends on it.
   if (!outputCanvas) {
     try {
       const result = await s.scan(fullCanvas, { mode: "extract", output: "canvas" });

--- a/frontend/src/lib/useCamera.ts
+++ b/frontend/src/lib/useCamera.ts
@@ -1,13 +1,45 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 
+export interface CapturedImage {
+  imageData: ImageData;
+  /**
+   * "photo"  — full-resolution still from ImageCapture.takePhoto(); corners
+   *            from the live viewfinder do NOT apply (different resolution /
+   *            field of view), so the caller must re-detect on this image.
+   * "video"  — a frame grabbed from the preview stream; viewfinder corners
+   *            apply after scaling by the detection scale.
+   */
+  source: "photo" | "video";
+}
+
 interface UseCameraResult {
   videoRef: React.RefObject<HTMLVideoElement | null>;
   stream: MediaStream | null;
   error: string | null;
   ready: boolean;
-  captureFrame: () => ImageData | null;
+  capturePhoto: () => Promise<CapturedImage | null>;
   stop: () => void;
 }
+
+// If takePhoto() hasn't resolved by this point, fall back to a video frame.
+// Some devices never resolve the promise; others are just slow.
+const TAKE_PHOTO_TIMEOUT_MS = 2000;
+
+// Clamp the captured still's long edge. A full-sensor takePhoto() can be
+// 12-108MP; drawing that to a canvas and reading it back (repeatedly, down the
+// pipeline) either exhausts mobile memory or silently exceeds the browser
+// canvas-area cap (~16.7M px on iOS), which makes getImageData return a blank
+// buffer — a black page uploaded with no error. 4096 (≈12.6MP at 4:3) stays
+// under that cap and the common 4096px GPU texture limit, preserves a full
+// ~12MP still intact, and always exceeds a 4K preview so the photo path can
+// never return less than the video-frame fallback.
+const MAX_CAPTURE_DIM = 4096;
+
+// Last-resort readiness fallback: if neither loadedmetadata nor loadeddata
+// fires (autoplay blocked with deferred metadata on some browsers), force ready
+// once frames are actually flowing so the viewfinder can't latch on the black
+// loading overlay forever (issue #4).
+const READY_TIMEOUT_MS = 2500;
 
 export function useCamera(): UseCameraResult {
   const videoRef = useRef<HTMLVideoElement | null>(null);
@@ -15,6 +47,11 @@ export function useCamera(): UseCameraResult {
   const [error, setError] = useState<string | null>(null);
   const [ready, setReady] = useState(false);
 
+  // Effect A — acquire the stream once. Request the maximum resolution the
+  // device will grant (Android Chrome typically yields 4K; iOS Safari caps at
+  // ~720p regardless). Binding to the <video> element happens in Effect B so a
+  // null videoRef at resolve time is retried on the next render instead of
+  // being silently dropped (the black-screen race, issue #4).
   useEffect(() => {
     let cancelled = false;
 
@@ -23,8 +60,8 @@ export function useCamera(): UseCameraResult {
         const s = await navigator.mediaDevices.getUserMedia({
           video: {
             facingMode: { ideal: "environment" },
-            width: { ideal: 1920 },
-            height: { ideal: 1080 },
+            width: { ideal: 9999 },
+            height: { ideal: 9999 },
           },
         });
         if (cancelled) {
@@ -32,10 +69,6 @@ export function useCamera(): UseCameraResult {
           return;
         }
         setStream(s);
-        if (videoRef.current) {
-          videoRef.current.srcObject = s;
-          videoRef.current.onloadedmetadata = () => setReady(true);
-        }
       } catch (err: any) {
         if (!cancelled) {
           if (err.name === "NotAllowedError") {
@@ -61,7 +94,49 @@ export function useCamera(): UseCameraResult {
     };
   }, []);
 
-  const captureFrame = useCallback((): ImageData | null => {
+  // Effect B — bind the stream to the video element and track readiness.
+  // Runs after every render where `stream` changed, so videoRef is reliably
+  // attached (the <video> is rendered unconditionally). Handles the metadata
+  // race two ways: read readyState directly for the case where metadata is
+  // already loaded (the event would never fire again), and listen for both
+  // loadedmetadata and loadeddata for the case where it hasn't.
+  useEffect(() => {
+    const video = videoRef.current;
+    if (!video || !stream) return;
+
+    video.srcObject = stream;
+
+    // Re-gate readiness for this stream. Harmless on first bind (already false);
+    // on a re-bind it prevents `ready` staying stale-true across the new
+    // stream's metadata-load gap.
+    setReady(false);
+
+    const onReady = () => setReady(true);
+    if (video.readyState >= 1 /* HAVE_METADATA */) {
+      setReady(true);
+    } else {
+      video.addEventListener("loadedmetadata", onReady);
+      video.addEventListener("loadeddata", onReady);
+    }
+
+    // autoPlay is advisory on mobile — start playback explicitly.
+    video.play().catch(() => {});
+
+    const readyTimer = setTimeout(() => {
+      if (video.videoWidth > 0) setReady(true);
+    }, READY_TIMEOUT_MS);
+
+    return () => {
+      clearTimeout(readyTimer);
+      video.removeEventListener("loadedmetadata", onReady);
+      video.removeEventListener("loadeddata", onReady);
+    };
+  }, [stream]);
+
+  // Grab a frame from the live preview stream (capped at the preview
+  // resolution). Used as the fallback when a full-resolution still is
+  // unavailable.
+  const captureVideoFrame = useCallback((): ImageData | null => {
     const video = videoRef.current;
     if (!video || !ready) return null;
     const canvas = document.createElement("canvas");
@@ -72,11 +147,82 @@ export function useCamera(): UseCameraResult {
     return ctx.getImageData(0, 0, canvas.width, canvas.height);
   }, [ready]);
 
+  // Capture the highest-resolution image the device can provide.
+  //
+  // Primary path: ImageCapture.takePhoto() returns a full-sensor still, which
+  // triggers a dedicated autofocus/exposure pass (typically sharper than the
+  // preview). We only trust it if it's genuinely larger than the preview frame
+  // — some devices return an upscaled preview from takePhoto().
+  //
+  // Fallback (iOS, Firefox, timeout, failure, or a faked still): a max-res
+  // video frame. The worst case here equals a stream-only implementation.
+  const capturePhoto = useCallback(async (): Promise<CapturedImage | null> => {
+    const video = videoRef.current;
+    if (!video || !ready) return null;
+
+    if (stream && "ImageCapture" in window) {
+      const track = stream.getVideoTracks()[0];
+      if (track) {
+        let timeoutId: ReturnType<typeof setTimeout> | undefined;
+        try {
+          const capture = new ImageCapture(track);
+          const blob = await Promise.race([
+            capture.takePhoto(),
+            new Promise<never>((_, reject) => {
+              timeoutId = setTimeout(() => reject(new Error("takePhoto timeout")), TAKE_PHOTO_TIMEOUT_MS);
+            }),
+          ]);
+          const bitmap = await createImageBitmap(blob);
+          try {
+            // Compare the long edge, not width — the still may come back in a
+            // different orientation than the preview (portrait sensor vs
+            // landscape stream), and a width-only test would reject a genuinely
+            // higher-resolution photo.
+            const photoLongEdge = Math.max(bitmap.width, bitmap.height);
+            const previewLongEdge = Math.max(video.videoWidth, video.videoHeight);
+            // Gate on what we can actually DELIVER (after the clamp), not the
+            // raw sensor size — otherwise a huge still that clamps below the
+            // preview would be accepted and hand back less than the video-frame
+            // fallback would.
+            const deliverableLongEdge = Math.min(photoLongEdge, MAX_CAPTURE_DIM);
+            if (deliverableLongEdge > previewLongEdge) {
+              // Downscale to a bounded long edge so a huge sensor still can't
+              // OOM the tab or overflow the canvas-area cap (see MAX_CAPTURE_DIM).
+              const clampScale = Math.min(1, MAX_CAPTURE_DIM / photoLongEdge);
+              const w = Math.round(bitmap.width * clampScale);
+              const h = Math.round(bitmap.height * clampScale);
+              const canvas = document.createElement("canvas");
+              canvas.width = w;
+              canvas.height = h;
+              const ctx = canvas.getContext("2d")!;
+              ctx.imageSmoothingEnabled = true;
+              ctx.imageSmoothingQuality = "high";
+              ctx.drawImage(bitmap, 0, 0, w, h);
+              const imageData = ctx.getImageData(0, 0, w, h);
+              return { imageData, source: "photo" };
+            }
+          } finally {
+            bitmap.close();
+          }
+        } catch {
+          // Fall through to the video-frame path.
+        } finally {
+          // takePhoto() usually wins the race; clear the loser so we don't leak
+          // a live timer (and a late rejection) for up to TAKE_PHOTO_TIMEOUT_MS.
+          clearTimeout(timeoutId);
+        }
+      }
+    }
+
+    const frame = captureVideoFrame();
+    return frame ? { imageData: frame, source: "video" } : null;
+  }, [ready, stream, captureVideoFrame]);
+
   const stop = useCallback(() => {
     stream?.getTracks().forEach((t) => t.stop());
     setStream(null);
     setReady(false);
   }, [stream]);
 
-  return { videoRef, stream, error, ready, captureFrame, stop };
+  return { videoRef, stream, error, ready, capturePhoto, stop };
 }

--- a/frontend/src/pages/ScannerPage.tsx
+++ b/frontend/src/pages/ScannerPage.tsx
@@ -65,13 +65,13 @@ export default function ScannerPage() {
   }, [dispatch, unsupported, insecure, classical, ml]);
 
   const handleCapture = useCallback(
-    async (imageData: ImageData, corners: Quad | null) => {
+    async (imageData: ImageData, corners: Quad | null, detectionScale: number) => {
       try {
         dispatch({ type: "captured", canvas: null as any, enhanced: null });
 
         uploadTestFrame(imageData, detector.name, corners);
 
-        const result = await extractAndEnhance(imageData, corners);
+        const result = await extractAndEnhance(imageData, corners, detectionScale);
 
         dispatch({ type: "captured", canvas: result.original, enhanced: result.enhanced });
       } catch (err: any) {

--- a/frontend/src/types/image-capture.d.ts
+++ b/frontend/src/types/image-capture.d.ts
@@ -1,0 +1,12 @@
+// Minimal ImageCapture declaration. The API ships in Chromium/Android but is
+// not in this project's TS lib.dom, and is absent entirely on iOS Safari and
+// Firefox — always feature-detect (`"ImageCapture" in window`) before use.
+interface ImageCapture {
+  takePhoto(photoSettings?: Record<string, unknown>): Promise<Blob>;
+  grabFrame(): Promise<ImageBitmap>;
+}
+
+declare const ImageCapture: {
+  prototype: ImageCapture;
+  new (track: MediaStreamTrack): ImageCapture;
+};


### PR DESCRIPTION
## Summary

Fixes two mobile scanner bugs, reviewed across four rounds this session (8-angle code review + specialist panel + three adversarial passes).

**#3 — low-res/blurry scans.** Capture grabbed a ~1080p video frame instead of a full-sensor photo. Now captures via `ImageCapture.takePhoto()` (full sensor on Android/Chrome) with a max-resolution video-frame fallback for iOS Safari / Firefox / timeout / devices that fake the still. On the full-res photo path the document is re-detected on the still itself, since viewfinder corners were measured against the lower-res preview and don't map across the resolution/FOV difference.

**#4 — black screen on Android.** The camera intermittently never activated due to a `loadedmetadata`/`videoRef` race. Init is now split into two effects (acquire stream + reactively bind), reads `readyState` directly, listens for both `loadedmetadata` and `loadeddata`, calls `play()` explicitly, and has a readiness timeout so the viewfinder can't latch on the black loading overlay.

## Key safety details
- **Still clamped to 4096px long edge** — a full-sensor `takePhoto()` can be 12–108MP; unclamped, the multi-copy canvas pipeline either OOMs the tab or silently exceeds the mobile canvas-area cap (~16.7M px), where `getImageData` returns a blank buffer and a black page uploads with no error. 4096 stays under that cap and the GPU texture limit while beating any 4K preview.
- **In-flight capture guard** — `takePhoto()` can take up to 2s; a synchronous `capturingRef` prevents a double-tap from firing overlapping captures.
- **Adaptive detection scale** — capped at 800px long edge so a 4K preview doesn't quadruple the live-detector's per-frame work.

## Files
- `frontend/src/lib/useCamera.ts` — capture + init rewrite
- `frontend/src/components/scanner/CameraViewfinder.tsx` — async capture, adaptive scale, in-flight guard
- `frontend/src/pages/ScannerPage.tsx` — thread detection scale to extraction
- `frontend/src/lib/opencv-loader.ts` — docstring for the re-detect contract
- `frontend/src/types/image-capture.d.ts` — ambient `ImageCapture` type (new)

## Verification
- Frontend `npm run build` (tsc -b + vite build): passes clean.
- No frontend test framework in the repo; capture paths are device-dependent and need manual QA on Android Chrome (photo path), iOS Safari (video fallback), and a long-receipt legibility check on a high-MP phone.
- Backend untouched (0 backend files in the diff).

## Follow-ups (not in this PR)
- Diagnostic test-frame corpus doesn't record the now-adaptive detection scale (needs a small schema change).
- `ImageCapture.takePhoto()` uses a device matrix best confirmed via manual QA.

## Note
This branch also carries one pre-approved chore commit (`chore: migrate gstack from vendored submodule to team mode`) that isn't part of the scanner fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)