### PR TITLE
fix: tolerant JSON parse ladder + Gemini JSON mode for LLM extraction (#10)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,7 +21,7 @@
 # RECEIPTORY_LLM_MAX_TOKENS=16384       # increase if JSON gets truncated
 # RECEIPTORY_LLM_JSON_MODE=true         # request JSON mode (response_format json_object); dropped on models without support
 # RECEIPTORY_LLM_SLEEP_INTERVAL=0.0     # seconds between LLM calls (rate limiting)
-# RECEIPTORY_CONFIDENCE_THRESHOLD=0.7   # 0 = never flag for review, 1 = flag everything
+# RECEIPTORY_CONFIDENCE_THRESHOLD=0.7   # 1 = flag everything; docs missing a confidence score are always flagged
 
 # --- Telegram bot (get token from @BotFather, bot name shown in Settings > Telegram) ---
 # RECEIPTORY_TELEGRAM_BOT_TOKEN=123456:ABC-your-token

--- a/.env.example
+++ b/.env.example
@@ -19,6 +19,7 @@
 # RECEIPTORY_LLM_MODEL=gemini/gemini-3-flash-preview
 # RECEIPTORY_LLM_TEMPERATURE=0.0        # 0 = deterministic
 # RECEIPTORY_LLM_MAX_TOKENS=16384       # increase if JSON gets truncated
+# RECEIPTORY_LLM_JSON_MODE=true         # request JSON mode (response_format json_object); dropped on models without support
 # RECEIPTORY_LLM_SLEEP_INTERVAL=0.0     # seconds between LLM calls (rate limiting)
 # RECEIPTORY_CONFIDENCE_THRESHOLD=0.7   # 0 = never flag for review, 1 = flag everything
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,9 +80,9 @@ cd .claude/skills/gstack && ./setup
 ## Key Design Decisions
 
 - **Config precedence:** environment variable > database setting > default value
-- **Categories:** soft-delete (`is_deleted` flag). System categories (`pending`, `not_a_receipt`, `failed`) cannot be deleted. Category `description` field is fed into the LLM prompt to guide classification.
+- **Categories:** soft-delete (`is_deleted` flag). System categories (`pending`, `uncategorized`, `failed`) cannot be deleted. Category `description` field is fed into the LLM prompt to guide classification.
 - **Document type detection:** LLM classifies, but code overrides to `issued_invoice` if `vendor_tax_id` matches any of the user's `business_tax_ids`.
-- **LLM JSON handling:** extraction requests JSON mode (`llm_json_mode` setting, env `RECEIPTORY_LLM_JSON_MODE`, default true; litellm `drop_params` skips it on models without `response_format` support). Salvaged parses get a confidence penalty; missing `extraction_confidence` routes the document to `needs_review`. A/B harness: `scripts/compare_json_mode.py`.
+- **LLM JSON handling:** extraction requests JSON mode (`llm_json_mode` setting, env `RECEIPTORY_LLM_JSON_MODE`, default true; litellm `drop_params` skips it on models without `response_format` support). Salvaged parses get a confidence penalty; missing or below-threshold `extraction_confidence` routes the document to `needs_review`. A/B harness: `scripts/compare_json_mode.py`.
 - **Deduplication:** SHA-256 file hash. Exact duplicates rejected at upload.
 - **Filing:** Stored as `yyyy-mm-dd-vendor_receipt_id-hash.pdf`. Three copies: `originals/` (by hash), `converted/` (if format conversion), `filed/` (human-readable name).
 - **FTS5:** Virtual table indexes `raw_extracted_text`, `vendor_name`, `description`, `document_title`. Sync triggers on insert/update/delete.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,6 +30,7 @@ frontend/src/           # React SPA
   pages/                # Page components
   components/           # Reusable UI components
 migrations/             # Numbered SQL files (001_initial_schema.sql, ...)
+scripts/                # Dev utilities (compare_json_mode.py A/B harness)
 tests/                  # pytest test suite
 ```
 
@@ -66,7 +67,7 @@ cd .claude/skills/gstack && ./setup
 - **Single process:** FastAPI app with background asyncio tasks for the processing queue and backup scheduler. No separate worker or message broker.
 - **Database:** SQLite in WAL mode. Hand-rolled migrations (numbered SQL files in `migrations/`). `schema_version` table tracks applied versions. Global `_db_path` is set by `init_db()` and protected by a threading lock.
 - **Processing pipeline:** Documents are processed sequentially. Queue polls for `status='pending'`, sets to `processing`, runs normalize → LLM extract → file → update DB. Failures set `status='failed'` with error message.
-- **LLM extraction:** Single-pass via litellm. Prompt includes user's business info (names, addresses, tax IDs in multiple languages) and category list with descriptions. Response is JSON parsed into `ExtractionResult` dataclass.
+- **LLM extraction:** Single-pass via litellm. Prompt includes user's business info (names, addresses, tax IDs in multiple languages) and category list with descriptions. Response is parsed into `ExtractionResult` via a tolerant JSON parse ladder (strict parse → fence/salvage recovery).
 - **Static files in production:** `app.mount("/", StaticFiles(...))` serves `frontend/dist/`. This catch-all mount MUST be registered last (after all API routes) and is disabled when `RECEIPTORY_DEV=1`.
 
 ## Testing
@@ -81,6 +82,7 @@ cd .claude/skills/gstack && ./setup
 - **Config precedence:** environment variable > database setting > default value
 - **Categories:** soft-delete (`is_deleted` flag). System categories (`pending`, `not_a_receipt`, `failed`) cannot be deleted. Category `description` field is fed into the LLM prompt to guide classification.
 - **Document type detection:** LLM classifies, but code overrides to `issued_invoice` if `vendor_tax_id` matches any of the user's `business_tax_ids`.
+- **LLM JSON handling:** extraction requests JSON mode (`llm_json_mode` setting, env `RECEIPTORY_LLM_JSON_MODE`, default true; litellm `drop_params` skips it on models without `response_format` support). Salvaged parses get a confidence penalty; missing `extraction_confidence` routes the document to `needs_review`. A/B harness: `scripts/compare_json_mode.py`.
 - **Deduplication:** SHA-256 file hash. Exact duplicates rejected at upload.
 - **Filing:** Stored as `yyyy-mm-dd-vendor_receipt_id-hash.pdf`. Three copies: `originals/` (by hash), `converted/` (if format conversion), `filed/` (human-readable name).
 - **FTS5:** Virtual table indexes `raw_extracted_text`, `vendor_name`, `description`, `document_title`. Sync triggers on insert/update/delete.

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ All data lives in `data/` (mounted as a Docker volume) and survives container re
 
 ## Configuration
 
-All settings are configurable via the admin UI. Environment variables take precedence over database values.
+Most settings are configurable via the admin UI. Environment variables take precedence over database values.
 
 | Variable | Default | Description |
 |---|---|---|
@@ -341,6 +341,7 @@ receiptory/
 │   ├── contexts/              # Auth + Theme providers
 │   └── lib/                   # API client, hooks, utilities
 ├── migrations/                # Numbered SQL migration files
+├── scripts/                   # Dev utilities (JSON-mode A/B harness)
 ├── tests/                     # pytest test suite
 ├── Dockerfile                 # Multi-stage build
 └── docker-compose.yml

--- a/TODOS.md
+++ b/TODOS.md
@@ -1,10 +1,121 @@
-# Project TODOs
+# TODOS
 
-Deferred items captured during planning and review. Each entry includes the why, current state, and where to start.
+Deferred items captured during planning and review. Organized by component, sorted by priority (P0 highest). Each entry includes the why, current state, and where to start.
 
----
+## Testing
 
-## Test set as ML fine-tuning corpus
+### Fix pre-existing auth login test failure (401)
+
+**What:** `tests/test_auth_api.py::test_login_success` returns 401 instead of 200. Root-cause and fix.
+
+**Why:** The failure predates the issue #10 branch (fails on master too) and will fail every future CI/ship run until fixed. May be environment-specific — observed in a containerized run of the suite (`docker run` from the production image with a fresh `uv sync` venv); worth reproducing in the normal dev environment first.
+
+**Context:**
+- Noticed by /ship on 2026-07-20 while shipping `fix/10-tolerant-json-parse`
+- Error: `assert 401 == 200` at tests/test_auth_api.py:33 (the `client` fixture logs in with admin/testpass after setup)
+- The companion stale-assert failure (`test_migration_version`) was fixed in that same PR; this one needs investigation, not a one-liner
+- Start: run the single test in the standard dev env; if it passes there, the bug is in the container test env (bcrypt wheels?), not the app
+
+**Effort:** S
+**Priority:** P0
+**Depends on:** None
+
+## Extraction
+
+### Typed response_schema structured output for extraction
+
+**What:** Upgrade the extraction LLM call from `json_object` mode to a full typed schema (litellm `response_format` with `json_schema`, mapping to Gemini's `response_schema`) so the model is constrained to the exact field names and types `parse_llm_response()` expects.
+
+**Why:** JSON mode (shipped with issue #10) guarantees *syntactically* valid JSON but not the right shape — wrong field names, string-where-number, or missing keys still pass silently into `data.get()` defaults.
+
+**Pros:**
+- Eliminates a whole class of silent field-level extraction misses
+- The schema doubles as executable documentation of the extraction contract
+
+**Cons:**
+- Gemini's schema dialect has quirks (limited unions/nullability support)
+- Over-constraining can degrade extraction quality on messy receipts — needs its own eval
+- Requires a drift check before becoming default
+
+**Context:**
+- Source: eng review of issue #10 (2026-07-20), decision D15
+- `scripts/compare_json_mode.py` (built for the #10 merge gate) is exactly the A/B harness this experiment should reuse — extend it to a third arm (schema mode)
+- The extraction fields live in `ExtractionResult` (backend/processing/extract.py) and the prompt's Required Output section
+
+**Effort:** M
+**Priority:** P2
+**Depends on:** Issue #10 shipped (json_object mode live and stable)
+
+## Scanner
+
+### Expand test corpus + per-bucket tagging
+
+**What:** Add a bucket field to the Scanner Lab (cluttered desk / dark background / harsh shadow / crumpled-long thermal), tag frames, and grow the corpus toward ~40+ per bucket for a statistically meaningful per-bucket eval.
+
+**Why:** The current 31-frame aggregate eval is directional only (~±17pp binomial CI at IoU≥0.85) and cannot see the crumpled/long-thermal failure mode that motivates the ML swap — yet that bucket is exactly what triggers the fine-tune contingency. Per-bucket numbers on a larger corpus turn the go/no-go from a coin-flip into a real measurement.
+
+**Pros:**
+- The `scanner_test_frames.notes` field + PATCH API already support tags; only a Lab UI field is missing
+- Makes the eval-gated default decision defensible per-bucket, not just aggregate
+
+**Cons:**
+- Meaningful per-bucket power needs many more labeled frames (phone-in-hand capture + annotation time)
+- Lab UI change (bucket dropdown wired to the notes field)
+
+**Context:**
+- Source: eng review 2026-07-06 — outside voice (n=31 statistical power) + D1 (aggregate-only eval chosen for v1)
+- Storage: `scanner_test_frames.ground_truth_json` (normalized quads) + `notes` (bucket tag)
+
+**Effort:** M
+**Priority:** P3
+**Depends on:** Only matters if the v1 aggregate eval is borderline and a sharper per-bucket decision is needed
+
+### WebGPU-guard for the live ML detection loop
+
+**What:** In the live viewfinder, run the ML detector only when WebGPU is available. If WebGPU is absent, keep the classical detector in the live loop and use WASM-backed ML only in the Lab / eval — never per-frame.
+
+**Why:** Single-threaded WASM ML at 256px (the chosen fallback, no COOP/COEP) can take 100–300ms+ per inference and jank the viewfinder. WebGPU (present on the S26 Ultra) makes this a non-issue, but a weaker device would degrade badly. A capability check keeps the live loop smooth everywhere.
+
+**Pros:**
+- Sidesteps janky-WASM-per-frame entirely via one `navigator.gpu` check
+- Composes with the A2 classical-fallback-with-indicator path already being built
+
+**Cons:**
+- Adds a capability-branch to the live detector selection
+- Means ML is "not live" on non-WebGPU devices even when selected (acceptable for a single-user WebGPU device)
+
+**Context:**
+- Source: eng review 2026-07-06, D8 (live detection cadence/threading), option C deferred by user
+- Design: `~/.gstack/projects/LevMuchnik-Receiptory/root-master-design-20260703-134251.md`
+- Related: A1 decision (self-host WASM single-threaded, no COOP/COEP)
+
+**Effort:** S
+**Priority:** P3
+**Depends on:** ML detection is shipped and live (Phase 1 of the ML detector plan). Only worth building if a non-WebGPU device enters the picture, or the S26 WASM fallback benchmark is bad
+
+### Web Worker for live detection
+
+**What:** Move the detection pipeline (preprocess + inference + parse) to a Web Worker using OffscreenCanvas + transferable ImageData, so the main thread never blocks during live detection.
+
+**Why:** Detection currently runs on the main thread, competing with the camera preview and React render. If the S26 Ultra benchmark shows the every-Nth-frame main-thread loop stuttering, a worker is the fix.
+
+**Pros:**
+- Main thread stays smooth regardless of detector cost
+- Use transferable objects to avoid the 10–30ms ImageData clone cost
+
+**Cons:**
+- ORT-web + WebGPU-in-worker support varies; OffscreenCanvas adds complexity
+- The design deliberately deferred this ("no Web Worker" simplification)
+
+**Context:**
+- Source: eng review 2026-07-06, D8, worker explicitly deferred
+- Only build if the S26 Ultra viewfinder actually janks under the chosen every-Nth-frame + smoother approach
+
+**Effort:** M
+**Priority:** P3
+**Depends on:** Phase 1 shipped; on-device benchmark shows main-thread stutter
+
+### Test set as ML fine-tuning corpus
 
 **What:** Once the scanner test set has 500+ annotated frames, evaluate fine-tuning the Sprint 3 ML detector on the user's distribution (Hebrew thermal-paper receipts, his specific lighting, his specific surfaces).
 
@@ -26,7 +137,32 @@ Deferred items captured during planning and review. Each entry includes the why,
 - Ground truth shape: same as `Quad` type (4 corners, normalized 0–1)
 - The Sprint 3 model selection (3.1 in the plan) should prefer architectures with documented fine-tuning recipes — don't pick a model whose weights are fixed-only
 
-**Depends on / blocked by:**
-- Sprint 3 ships first and proves off-the-shelf accuracy is meaningful but insufficient
-- Test set has accumulated ≥500 annotated frames (likely 2–3 months of daily use post-Sprint 1)
-- User has access to a machine that can run Python training (NAS likely cannot; cloud GPU rental or local workstation)
+**Effort:** XL
+**Priority:** P3
+**Depends on:** Sprint 3 ships first and proves off-the-shelf accuracy is meaningful but insufficient. Test set has accumulated ≥500 annotated frames (likely 2–3 months of daily use post-Sprint 1). User has access to a machine that can run Python training (NAS likely cannot; cloud GPU rental or local workstation)
+
+### Persisted longitudinal eval store
+
+**What:** The `scanner_eval_results` + `scanner_eval_runs` tables + POST/GET API originally in the design (dropped in the 2026-07-06 review). Persist per-run detector results so runs survive reload and can be diffed over time.
+
+**Why:** If the eval gets re-run across many models (e.g. a series of fine-tuned DocAligner variants), a persisted store lets Claude diff runs and track accuracy/timing trends instead of one-shot JSON dumps.
+
+**Pros:**
+- Longitudinal comparison across model versions
+- Reuses the already-labeled `scanner_test_frames` corpus
+
+**Cons:**
+- Two new SQLite tables + API surface for what is today a handful of one-off runs
+- Duplicates what the Python spike computes for accuracy
+
+**Context:**
+- Source: eng review 2026-07-06, D10 — narrowed the eval to Python-accuracy + a thin on-device timing JSON probe; persistence deferred
+- Only justified once there's a multi-run eval *program* (fine-tune flywheel active)
+
+**Effort:** M
+**Priority:** P4
+**Depends on:** Fine-tune flywheel active, or a recurring need to compare many model versions
+
+## Completed
+
+_No completed items yet._

--- a/backend/config.py
+++ b/backend/config.py
@@ -17,6 +17,7 @@ DEFAULTS: dict[str, Any] = {
     "llm_api_key": "",
     "llm_temperature": 0.0,
     "llm_max_tokens": 8192,
+    "llm_json_mode": True,
     "llm_sleep_interval": 0.0,
     "confidence_threshold": 0.7,
     "auth_username": "admin",

--- a/backend/processing/extract.py
+++ b/backend/processing/extract.py
@@ -1,4 +1,5 @@
 import json
+import math
 import re
 import base64
 import logging
@@ -33,6 +34,9 @@ class ExtractionResult:
     document_type: str | None = None
     category_name: str | None = None
     extraction_confidence: float | None = None
+    # Parse metadata, not document data: True when the fence/salvage tiers
+    # (T2/T3) recovered the payload — the model deviated from instructions.
+    parse_salvaged: bool = False
 
 
 @dataclass
@@ -90,29 +94,199 @@ Return a single JSON object with these fields:
 Return ONLY the JSON object, no markdown fences or explanation."""
 
 
-def parse_llm_response(response_text: str) -> ExtractionResult:
-    text = response_text.strip()
-    fence_match = re.search(r"```(?:json)?\s*\n?(.*?)\n?\s*```", text, re.DOTALL)
-    if fence_match:
-        text = fence_match.group(1).strip()
+_JSON_DECODER = json.JSONDecoder()
+_FENCE_OPEN_RE = re.compile(r"```(?:json)?", re.IGNORECASE)
+# Shape gate: a decoded dict must share at least TWO keys with the extraction
+# schema, or it is a decoy/garbage/fragment (e.g. {} from JSON mode, an example
+# object inside model prose, or a lone line item from a truncated response)
+# and the candidate fails rather than filing an all-None record as processed.
+_EXPECTED_KEYS = frozenset({
+    "receipt_date", "document_title", "vendor_name", "vendor_tax_id", "vendor_receipt_id",
+    "client_name", "client_tax_id", "description", "line_items", "subtotal", "tax_amount",
+    "total_amount", "currency", "payment_method", "payment_identifier", "language",
+    "additional_fields", "raw_extracted_text", "document_type", "category", "extraction_confidence",
+})
+# A parse recovered via the fence or salvage tier means the model deviated
+# from instructions — trust the result a little less.
+_SALVAGE_CONFIDENCE_FACTOR = 0.9
+_CONTROL_CHARS_RE = re.compile(r"[\x00-\x08\x0b-\x1f\x7f-\x9f]")  # keep \t and \n
+_TRAILING_SNIPPET_CHARS = 500
+_FAILURE_LOG_CHARS = 2000
+_MAX_SALVAGE_ATTEMPTS = 1000
+
+
+def _sanitize_for_log(text: str) -> str:
+    """Strip control chars (except tab/newline) so LLM/OCR content can't forge or corrupt log records (ANSI escapes etc.)."""
+    return _CONTROL_CHARS_RE.sub(" ", text)
+
+
+def _as_float(value: Any) -> float | None:
+    """json_object mode guarantees valid JSON, not types — models sometimes emit numbers as strings.
+
+    Rejects bools (True would coerce to 1.0) and non-finite values: Python's
+    json parser accepts NaN/Infinity constants, and NaN defeats comparison
+    gates (NaN < x is always False) while sqlite3 silently stores it as NULL.
+    """
+    if value is None or isinstance(value, bool):
+        return None
     try:
-        data = json.loads(text)
-    except json.JSONDecodeError as e:
-        logger.error(f"LLM returned invalid JSON. Raw response:\n{text[:2000]}")
-        raise ValueError(f"Failed to parse LLM response as JSON: {e}")
+        result = float(value)
+    except (TypeError, ValueError):
+        return None
+    return result if math.isfinite(result) else None
+
+
+def _decode_leading_object(text: str, start: int = 0) -> tuple[dict, str] | None:
+    """raw_decode a JSON value at start (skipping whitespace); accept only extraction-shaped objects.
+
+    Returns (payload, trailing_text), or None when the text at start does
+    not begin with valid JSON, the leading value is not a dict, or the dict
+    shares no keys with the extraction schema (a decoy/garbage object). All
+    of these are tier failures, not errors — the caller's ladder falls
+    through to the next tier. RecursionError guards against pathologically
+    nested input from the semi-trusted LLM, which the json module raises
+    instead of JSONDecodeError.
+    """
+    while start < len(text) and text[start].isspace():
+        start += 1
+    try:
+        data, end = _JSON_DECODER.raw_decode(text, start)
+    except (json.JSONDecodeError, RecursionError):
+        return None
+    if not isinstance(data, dict):
+        return None
+    # >=2 matching keys: a single shared key is not evidence of the payload —
+    # a truncated response's inner line item ({"description", "quantity",
+    # "unit_price"}) intersects the schema on exactly one key and must not
+    # be salvaged as the whole document.
+    if len(_EXPECTED_KEYS.intersection(data)) < 2:
+        return None
+    return data, text[end:]
+
+
+def parse_llm_response(response_text: str) -> ExtractionResult:
+    """Parse the LLM's extraction response, tolerating junk around the JSON.
+
+    Gemini intermittently keeps generating after emitting a complete JSON
+    object (issue #10), so parsing walks a tolerance ladder instead of a
+    strict json.loads():
+
+        response_text
+            | strip()
+            v
+        T1: raw_decode(text) ------------------- shaped dict? --> use it
+            | fail                                                ^
+            v                                                     |
+        T2: best-match salvage — candidates are the object        |
+            after a fence opening (```json / ```, closing         |
+            fence = trailing data) PLUS raw_decode at each        |
+            successive "{" (capped at _MAX_SALVAGE_ATTEMPTS).     |
+            The shaped dict sharing the MOST schema keys wins     |
+            (ties -> fence candidate) + salvage WARNING ----------+
+            | all fail
+            v
+        T3: ERROR log with head AND tail of response --> ValueError
+
+    "Shaped dict" = a JSON object sharing >=2 keys with the extraction
+    schema (_EXPECTED_KEYS) — a single shared key is a fragment/decoy, not
+    the payload. Non-dicts (number/string/array) and unshaped objects are
+    candidate failures — ValueError is raised only when the whole ladder
+    is exhausted. Any salvaged result (fence or scan) carries a confidence
+    penalty (_SALVAGE_CONFIDENCE_FACTOR) since the model deviated from
+    instructions. Non-whitespace trailing data after the decoded object
+    logs a WARNING with a snippet of what the model appended.
+    Head/tail/snippet logs contain document text — accepted for a
+    self-hosted single-user deployment.
+    """
+    text = response_text.strip()
+
+    salvaged = False
+    decoded = _decode_leading_object(text)
+    if decoded is None:
+        # Best-match salvage: the fence candidate (if any) and every "{"
+        # candidate compete on schema-key overlap — the real payload
+        # (~21 keys) always beats a prose-embedded or fenced example object,
+        # so a decoy earlier in the response can't hijack the parse. The
+        # fence candidate wins ties (it's the more explicit structure).
+        best: tuple[dict, str] | None = None
+        best_matched = 0
+        fence = _FENCE_OPEN_RE.search(text)
+        fence_candidate = _decode_leading_object(text, fence.end()) if fence else None
+        if fence_candidate is not None:
+            best, best_matched = fence_candidate, len(_EXPECTED_KEYS.intersection(fence_candidate[0]))
+        idx = text.find("{")
+        attempts = 0
+        while idx != -1 and attempts < _MAX_SALVAGE_ATTEMPTS:
+            candidate = _decode_leading_object(text, idx)
+            attempts += 1
+            if candidate is not None:
+                matched = len(_EXPECTED_KEYS.intersection(candidate[0]))
+                if matched > best_matched:
+                    best, best_matched = candidate, matched
+            idx = text.find("{", idx + 1)
+        if best is not None:
+            decoded = best
+            salvaged = True
+            if best is fence_candidate:
+                logger.warning("LLM response wrapped the JSON object in a markdown fence despite prompt/json_mode instructions")
+            else:
+                logger.warning("LLM response required salvage parsing: JSON object found mid-response after non-JSON leading text")
+    if decoded is None:
+        if len(text) <= 2 * _FAILURE_LOG_CHARS:
+            logged = text
+        else:
+            logged = f"{text[:_FAILURE_LOG_CHARS]}\n... [{len(text) - 2 * _FAILURE_LOG_CHARS} chars omitted] ...\n{text[-_FAILURE_LOG_CHARS:]}"
+        logger.error(f"LLM returned invalid JSON. Raw response (head and tail):\n{_sanitize_for_log(logged)}")
+        # Re-decode once to carry the parse detail into the stored
+        # processing_error and failure notification (#215 was diagnosed
+        # from exactly this detail).
+        try:
+            value, _ = _JSON_DECODER.raw_decode(text)
+        except (json.JSONDecodeError, RecursionError) as e:
+            detail = str(e)
+        else:
+            detail = "leading JSON object does not match the extraction schema" if isinstance(value, dict) else "leading JSON value is not an object"
+        raise ValueError(f"Failed to parse LLM response as JSON: {detail}")
+
+    data, trailing = decoded
+    trailing = trailing.strip()
+    if trailing.startswith("```"):
+        trailing = trailing.removeprefix("```").strip()
+    if trailing:
+        logger.warning(f"LLM response contained trailing data after the JSON object; ignored. Trailing snippet: {_sanitize_for_log(trailing[:_TRAILING_SNIPPET_CHARS])}")
+    line_items = data.get("line_items", [])
+    if isinstance(line_items, list):
+        # Same NaN/string-number defense as the scalar money fields: a NaN
+        # unit_price would serialize as invalid JSON (json.dumps allow_nan)
+        # and break every client-side JSON.parse of the stored line items.
+        for item in line_items:
+            if isinstance(item, dict):
+                for key in ("quantity", "unit_price"):
+                    if key in item:
+                        item[key] = _as_float(item[key])
+    else:
+        line_items = []
+    confidence = _as_float(data.get("extraction_confidence"))
+    if confidence is not None and not (0.0 <= confidence <= 1.0):
+        logger.warning(f"LLM returned out-of-range extraction_confidence {confidence}; treating as unknown")
+        confidence = None
+    if salvaged and confidence is not None:
+        confidence = round(confidence * _SALVAGE_CONFIDENCE_FACTOR, 4)
+        logger.warning(f"Salvaged parse: extraction confidence penalized by {round((1 - _SALVAGE_CONFIDENCE_FACTOR) * 100)}% to {confidence}")
     return ExtractionResult(
         receipt_date=data.get("receipt_date"), document_title=data.get("document_title"),
         vendor_name=data.get("vendor_name"), vendor_tax_id=data.get("vendor_tax_id"),
         vendor_receipt_id=data.get("vendor_receipt_id"), client_name=data.get("client_name"),
         client_tax_id=data.get("client_tax_id"), description=data.get("description"),
-        line_items=data.get("line_items", []), subtotal=data.get("subtotal"),
-        tax_amount=data.get("tax_amount"), total_amount=data.get("total_amount"),
+        line_items=line_items, subtotal=_as_float(data.get("subtotal")),
+        tax_amount=_as_float(data.get("tax_amount")), total_amount=_as_float(data.get("total_amount")),
         currency=data.get("currency"), payment_method=data.get("payment_method"),
         payment_identifier=data.get("payment_identifier"), language=data.get("language"),
         additional_fields=data.get("additional_fields", []),
         raw_extracted_text=data.get("raw_extracted_text"),
         document_type=data.get("document_type"), category_name=data.get("category"),
-        extraction_confidence=data.get("extraction_confidence"),
+        extraction_confidence=confidence,
+        parse_salvaged=salvaged,
     )
 
 
@@ -120,14 +294,52 @@ def litellm_completion(**kwargs):
     return litellm.completion(**kwargs)
 
 
-def extract_document(page_images: list[bytes], model: str, api_key: str, business_names: list[str], business_addresses: list[str], business_tax_ids: list[str], expense_categories: list[dict[str, str]], issued_categories: list[dict[str, str]], temperature: float = 0.0, max_tokens: int = 8192) -> LLMExtractionResult:
+def extract_document(page_images: list[bytes], model: str, api_key: str, business_names: list[str], business_addresses: list[str], business_tax_ids: list[str], expense_categories: list[dict[str, str]], issued_categories: list[dict[str, str]], temperature: float = 0.0, max_tokens: int = 8192, json_mode: bool = True) -> LLMExtractionResult:
     prompt = build_extraction_prompt(business_names=business_names, business_addresses=business_addresses, business_tax_ids=business_tax_ids, expense_categories=expense_categories, issued_categories=issued_categories)
     content: list[dict] = [{"type": "text", "text": prompt}]
     for img_bytes in page_images:
         b64 = base64.b64encode(img_bytes).decode("utf-8")
         content.append({"type": "image_url", "image_url": {"url": f"data:image/png;base64,{b64}"}})
-    response = litellm_completion(model=model, api_key=api_key, messages=[{"role": "user", "content": content}], temperature=temperature, max_tokens=max_tokens)
-    raw_content = response.choices[0].message.content
-    logger.debug(f"LLM response ({response.usage.completion_tokens} tokens):\n{raw_content[:500]}")
-    extraction = parse_llm_response(raw_content)
+    completion_kwargs: dict[str, Any] = dict(model=model, api_key=api_key, messages=[{"role": "user", "content": content}], temperature=temperature, max_tokens=max_tokens)
+    if json_mode:
+        # JSON mode stops trailing junk at the source (issue #10). drop_params
+        # is a blanket litellm flag: on a model without response_format support
+        # it silently drops ANY unsupported param (potentially temperature or
+        # max_tokens too) instead of erroring — accepted so a model swap can
+        # never brick extraction; the tolerant parser is the net.
+        completion_kwargs["response_format"] = {"type": "json_object"}
+        completion_kwargs["drop_params"] = True
+    response = litellm_completion(**completion_kwargs)
+    choice = response.choices[0]
+    raw_content = choice.message.content
+    finish_reason = getattr(choice, "finish_reason", None)
+    truncated = finish_reason == "length"
+    truncation_error = f"LLM response truncated at max_tokens={max_tokens} — increase the llm_max_tokens setting"
+    if not raw_content:
+        if truncated:
+            raise ValueError(truncation_error)
+        # Gemini safety/recitation blocks arrive as finish_reason=content_filter
+        # with empty content — carry the reason so the stored error is diagnosable.
+        raise ValueError(f"LLM returned an empty response (finish_reason={finish_reason})")
+    if not isinstance(raw_content, str):
+        raise ValueError(f"LLM returned unexpected content type: {type(raw_content).__name__}")
+    logger.debug(f"LLM response ({response.usage.completion_tokens} tokens):\n{_sanitize_for_log(raw_content[:500])}")
+    try:
+        extraction = parse_llm_response(raw_content)
+    except ValueError:
+        # A response that rambled into the token cap may still carry a
+        # complete leading object (the issue #10 shape) — only when the
+        # ladder can't recover one is truncation the actionable error.
+        if truncated:
+            logger.error(f"LLM response truncated at max_tokens={max_tokens} and no complete JSON object found. Tail:\n{_sanitize_for_log(raw_content[-_FAILURE_LOG_CHARS:])}")
+            raise ValueError(truncation_error)
+        raise
+    if truncated:
+        # A T2/T3-salvaged parse of a TRUNCATED response is untrustworthy: the
+        # ladder may have latched onto an inner fragment (e.g. a line item) of
+        # the incomplete document. Only a clean leading object (T1) counts.
+        if extraction.parse_salvaged:
+            logger.error(f"LLM response truncated at max_tokens={max_tokens}; salvage tier matched only a fragment — rejecting. Tail:\n{_sanitize_for_log(raw_content[-_FAILURE_LOG_CHARS:])}")
+            raise ValueError(truncation_error)
+        logger.warning(f"LLM response hit max_tokens={max_tokens} but a complete leading JSON object was parsed")
     return LLMExtractionResult(extraction=extraction, tokens_in=response.usage.prompt_tokens, tokens_out=response.usage.completion_tokens, model=model)

--- a/backend/processing/filing.py
+++ b/backend/processing/filing.py
@@ -1,9 +1,17 @@
 import re
 
+# ASCII-only + fullmatch: \d would accept Unicode digits, and match() with $
+# would accept a trailing newline into the filename.
+_DATE_RE = re.compile(r"[0-9]{4}-[0-9]{2}-[0-9]{2}")
+
 
 def generate_stored_filename(receipt_date: str | None, vendor_receipt_id: str | None, file_hash: str) -> str:
-    date_part = receipt_date if receipt_date else "0000-00-00"
-    id_part = vendor_receipt_id if vendor_receipt_id else "000000"
+    # Both values come verbatim from the LLM — validate type AND shape so a
+    # malformed value (e.g. "2026/01/15", or the date emitted as a JSON
+    # number) can't inject path separators/control characters or crash the
+    # regex with a TypeError.
+    date_part = receipt_date if isinstance(receipt_date, str) and _DATE_RE.fullmatch(receipt_date) else "0000-00-00"
+    id_part = vendor_receipt_id if vendor_receipt_id and isinstance(vendor_receipt_id, str) else "000000"
     hash_part = file_hash[:8]
     id_part = re.sub(r"[^a-zA-Z0-9\-_.]", "_", id_part)
     return f"{date_part}-{id_part}-{hash_part}.pdf"

--- a/backend/processing/pipeline.py
+++ b/backend/processing/pipeline.py
@@ -65,13 +65,16 @@ def _run_pipeline(doc_id: int, doc: dict, data_dir: str) -> None:
     issued_categories = [{"name": c["name"], "description": c["description"] or ""} for c in cats if c["section"] == "issued"]
     temperature = get_setting("llm_temperature")
     max_tokens = get_setting("llm_max_tokens")
-    llm_result = extract_document(page_images=page_images, model=model, api_key=api_key, business_names=business_names, business_addresses=business_addresses, business_tax_ids=business_tax_ids, expense_categories=expense_categories, issued_categories=issued_categories, temperature=temperature, max_tokens=max_tokens)
+    json_mode = get_setting("llm_json_mode")
+    llm_result = extract_document(page_images=page_images, model=model, api_key=api_key, business_names=business_names, business_addresses=business_addresses, business_tax_ids=business_tax_ids, expense_categories=expense_categories, issued_categories=issued_categories, temperature=temperature, max_tokens=max_tokens, json_mode=json_mode)
     ext = llm_result.extraction
     doc_type = ext.document_type
     if ext.vendor_tax_id and ext.vendor_tax_id in business_tax_ids:
         doc_type = "issued_invoice"
     status = "processed"
-    if ext.extraction_confidence is not None and ext.extraction_confidence < confidence_threshold:
+    # Missing confidence is NOT full confidence — a response that omitted the
+    # score (wrong-shaped but salvageable JSON) deserves a human eye.
+    if ext.extraction_confidence is None or ext.extraction_confidence < confidence_threshold:
         status = "needs_review"
     stored_filename = generate_stored_filename(receipt_date=ext.receipt_date, vendor_receipt_id=ext.vendor_receipt_id, file_hash=file_hash)
     save_filed(pdf_path, stored_filename, data_dir)
@@ -93,7 +96,7 @@ def _run_pipeline(doc_id: int, doc: dict, data_dir: str) -> None:
     now = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
     with get_connection() as conn:
         conn.execute("""UPDATE documents SET document_type = ?, stored_filename = ?, page_count = ?, receipt_date = ?, document_title = ?, vendor_name = ?, vendor_tax_id = ?, vendor_receipt_id = ?, client_name = ?, client_tax_id = ?, description = ?, line_items = ?, subtotal = ?, tax_amount = ?, total_amount = ?, currency = ?, payment_method = ?, payment_identifier = ?, language = ?, additional_fields = ?, raw_extracted_text = ?, category_id = ?, status = ?, extraction_confidence = ?, processing_model = ?, processing_tokens_in = ?, processing_tokens_out = ?, processing_cost_usd = ?, processing_date = ?, processing_attempts = processing_attempts + 1, processing_error = NULL, updated_at = ? WHERE id = ?""",
-            (doc_type, stored_filename, page_count, ext.receipt_date, ext.document_title, ext.vendor_name, ext.vendor_tax_id, ext.vendor_receipt_id, ext.client_name, ext.client_tax_id, ext.description, json.dumps(ext.line_items) if ext.line_items else None, ext.subtotal, ext.tax_amount, ext.total_amount, ext.currency, ext.payment_method, ext.payment_identifier, ext.language, json.dumps(ext.additional_fields) if ext.additional_fields else None, ext.raw_extracted_text, category_id, status, ext.extraction_confidence, llm_result.model, llm_result.tokens_in, llm_result.tokens_out, _estimate_cost(llm_result.model, llm_result.tokens_in, llm_result.tokens_out), now, now, doc_id))
+            (doc_type, stored_filename, page_count, ext.receipt_date, ext.document_title, ext.vendor_name, ext.vendor_tax_id, ext.vendor_receipt_id, ext.client_name, ext.client_tax_id, ext.description, json.dumps(ext.line_items) if ext.line_items else None, ext.subtotal, ext.tax_amount, ext.total_amount, ext.currency, ext.payment_method, ext.payment_identifier, ext.language, json.dumps(ext.additional_fields) if ext.additional_fields else None, ext.raw_extracted_text, category_id, status, ext.extraction_confidence, llm_result.model, llm_result.tokens_in, llm_result.tokens_out, estimate_cost(llm_result.model, llm_result.tokens_in, llm_result.tokens_out), now, now, doc_id))
     logger.info(f"Document {doc_id} processed successfully: {status}")
     try:
         from backend.notifications.notifier import notify
@@ -114,7 +117,7 @@ def _run_pipeline(doc_id: int, doc: dict, data_dir: str) -> None:
         pass
 
 
-def _estimate_cost(model: str, tokens_in: int, tokens_out: int) -> float:
+def estimate_cost(model: str, tokens_in: int, tokens_out: int) -> float:
     pricing = {"gemini/gemini-3-flash-preview": (0.10, 0.40), "gpt-4o": (2.50, 10.00), "claude-sonnet-4-20250514": (3.00, 15.00)}
     in_rate, out_rate = pricing.get(model, (1.0, 3.0))
     return (tokens_in * in_rate + tokens_out * out_rate) / 1_000_000

--- a/scripts/compare_json_mode.py
+++ b/scripts/compare_json_mode.py
@@ -1,0 +1,198 @@
+"""Issue #10 merge gate: A/B-compare extraction with JSON mode off vs on.
+
+Runs each sampled processed document through extract_document() twice —
+once without response_format (off) and once with json_object mode (on) —
+and diffs key fields between the two FRESH runs. That off-vs-on diff is
+the merge gate: it isolates the JSON-mode delta from months of unrelated
+model/prompt drift. Stored DB values are printed as a reference column
+only.
+
+The script issues no writes of its own, but init_db() is not free: it
+creates the DB file if absent and applies unapplied migrations. The
+existence guard in main() refuses to run against a missing DB so a wrong
+--data-dir can never silently create a fresh database.
+
+Run from a host environment with backend deps (scripts/ is not baked into
+the Docker image), pointed at the production data dir:
+    python scripts/compare_json_mode.py [--data-dir data] [--sample-size 18]
+"""
+
+import argparse
+import logging
+import os
+import sys
+import time
+from collections import defaultdict
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from dotenv import load_dotenv
+
+# litellm's .env auto-load is import-order dependent; load explicitly so
+# RECEIPTORY_* settings (notably the API key) are present regardless.
+load_dotenv(os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), ".env"))
+
+from backend.database import init_db, get_connection
+from backend.config import get_setting
+from backend.storage import get_file_path, render_all_pages_to_memory
+from backend.processing.extract import extract_document
+from backend.processing.pipeline import estimate_cost
+
+COMPARE_FIELDS = ["vendor_name", "receipt_date", "total_amount", "tax_amount", "category_name", "document_type"]
+
+
+def pick_sample(limit: int) -> list[dict]:
+    """Stratified sample: round-robin across (document_type, vendor) buckets."""
+    with get_connection() as conn:
+        rows = conn.execute(
+            """SELECT d.id, d.original_filename, d.file_hash, d.stored_filename, d.language,
+                      d.vendor_name, d.receipt_date, d.total_amount, d.tax_amount, d.document_type,
+                      c.name AS category_name
+               FROM documents d LEFT JOIN categories c ON d.category_id = c.id
+               WHERE d.status IN ('processed', 'needs_review') AND d.is_deleted = 0
+               ORDER BY d.id DESC"""
+        ).fetchall()
+    buckets: dict[tuple, list] = defaultdict(list)
+    for r in rows:
+        buckets[(r["document_type"], r["vendor_name"])].append(dict(r))
+    sample: list[dict] = []
+    while len(sample) < limit and any(buckets.values()):
+        for key in sorted(buckets, key=lambda k: (str(k[0]), str(k[1]))):
+            if buckets[key] and len(sample) < limit:
+                sample.append(buckets[key].pop(0))
+    return sample
+
+
+def resolve_pdf(doc: dict, data_dir: str) -> str | None:
+    """Prefer the filed PDF (what the pipeline extracted from), then converted, then a PDF original."""
+    if doc["stored_filename"]:
+        filed = os.path.join(data_dir, "storage", "filed", doc["stored_filename"])
+        if os.path.exists(filed):
+            return filed
+    converted = get_file_path("converted", doc["file_hash"], ".pdf", data_dir)
+    if os.path.exists(converted):
+        return converted
+    ext = os.path.splitext(doc["original_filename"])[1].lower()
+    if ext == ".pdf":
+        original = get_file_path("original", doc["file_hash"], ext, data_dir)
+        if os.path.exists(original):
+            return original
+    return None
+
+
+def extraction_args() -> dict:
+    with get_connection() as conn:
+        cats = conn.execute("SELECT name, description, section FROM categories WHERE is_deleted = 0 AND is_system = 0").fetchall()
+    return dict(
+        model=get_setting("llm_model"),
+        api_key=get_setting("llm_api_key"),
+        business_names=get_setting("business_names"),
+        business_addresses=get_setting("business_addresses"),
+        business_tax_ids=get_setting("business_tax_ids"),
+        expense_categories=[{"name": c["name"], "description": c["description"] or ""} for c in cats if c["section"] == "expense"],
+        issued_categories=[{"name": c["name"], "description": c["description"] or ""} for c in cats if c["section"] == "issued"],
+        temperature=get_setting("llm_temperature"),
+        max_tokens=get_setting("llm_max_tokens"),
+    )
+
+
+def fmt(v) -> str:
+    return "—" if v is None else str(v)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--data-dir", default=os.environ.get("RECEIPTORY_DATA_DIR", "data"))
+    parser.add_argument("--sample-size", type=int, default=18)
+    args = parser.parse_args()
+
+    logging.basicConfig(level=logging.WARNING, format="%(levelname)s %(name)s: %(message)s")
+    data_dir = os.path.abspath(args.data_dir)
+    db_path = os.path.join(data_dir, "receiptory.db")
+    if not os.path.exists(db_path):
+        # init_db would CREATE a fresh DB + schema here — refuse instead so a
+        # wrong --data-dir can never masquerade as an empty corpus.
+        print(f"No database at {db_path} — check --data-dir / RECEIPTORY_DATA_DIR. Aborting.")
+        return 2
+    # init_db also APPLIES unapplied migrations. Running this script from a
+    # newer checkout must never schema-upgrade a production DB out from under
+    # an older running container — refuse instead.
+    import glob
+    import sqlite3
+    migration_count = len(glob.glob(os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "migrations", "*.sql")))
+    with sqlite3.connect(f"file:{db_path}?mode=ro", uri=True) as ro_conn:
+        try:
+            db_version = ro_conn.execute("SELECT MAX(version) FROM schema_version").fetchone()[0] or 0
+        except sqlite3.OperationalError:
+            db_version = 0
+    if db_version < migration_count:
+        print(f"DB schema version {db_version} is behind this checkout's {migration_count} migrations — deploy first, then run the comparison. Aborting.")
+        return 2
+    init_db(db_path)
+
+    sample = pick_sample(args.sample_size)
+    if not sample:
+        print("No processed documents found — nothing to compare.")
+        return 1
+    base_args = extraction_args()
+    if not base_args["api_key"]:
+        print("No LLM API key found (RECEIPTORY_LLM_API_KEY env / .env, or llm_api_key DB setting). Aborting before any LLM call.")
+        return 2
+    dpi = get_setting("page_render_dpi")
+
+    docs_with_diffs = 0
+    field_diff_counts: dict[str, int] = defaultdict(int)
+    total_in = total_out = 0
+    skipped: list[str] = []
+
+    sleep_interval = get_setting("llm_sleep_interval")
+
+    for doc in sample:
+        pdf = resolve_pdf(doc, data_dir)
+        if pdf is None:
+            skipped.append(f"#{doc['id']} ({doc['original_filename']}): no PDF found")
+            continue
+        try:
+            pages = render_all_pages_to_memory(pdf, dpi=dpi)
+            results = {}
+            for label, json_mode in (("OFF", False), ("ON", True)):
+                llm_result = extract_document(page_images=pages, json_mode=json_mode, **base_args)
+                results[label] = llm_result.extraction
+                total_in += llm_result.tokens_in
+                total_out += llm_result.tokens_out
+                if sleep_interval > 0:
+                    time.sleep(sleep_interval)  # mirror the queue's provider rate-limit pacing
+        except Exception as e:
+            # One bad doc must not discard the whole run (and its token spend).
+            skipped.append(f"#{doc['id']} ({doc['original_filename']}): {e}")
+            continue
+
+        off, on = results["OFF"], results["ON"]
+        diffs = [f for f in COMPARE_FIELDS if getattr(off, f) != getattr(on, f)]
+        if diffs:
+            docs_with_diffs += 1
+            for f in diffs:
+                field_diff_counts[f] += 1
+
+        marker = "DIFF" if diffs else "same"
+        print(f"\nDoc #{doc['id']}  {doc['original_filename']}  ({doc['document_type']}, {doc['language'] or '?'})  [{marker}]")
+        print(f"  {'field':<16} {'OFF':<32} {'ON':<32} {'DB(ref)':<32}")
+        for f in COMPARE_FIELDS:
+            flag = "  <-- off!=on" if f in diffs else ""
+            print(f"  {f:<16} {fmt(getattr(off, f)):<32.32} {fmt(getattr(on, f)):<32.32} {fmt(doc.get(f)):<32.32}{flag}")
+
+    model = base_args["model"]
+    cost = estimate_cost(model, total_in, total_out)
+    print("\n" + "=" * 72)
+    print(f"SUMMARY: {docs_with_diffs}/{len(sample) - len(skipped)} docs with off-vs-on diffs")
+    for f, n in sorted(field_diff_counts.items()):
+        print(f"  {f}: {n} diff(s)")
+    if skipped:
+        print(f"Skipped {len(skipped)}: " + "; ".join(skipped))
+    print(f"Tokens: {total_in} in / {total_out} out across {2 * (len(sample) - len(skipped))} extractions (~${cost:.2f} at {model} rates)")
+    print("Gate: eyeball any off!=on rows above — systematic drift blocks the merge; one-off nondeterminism does not.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,9 @@
+import json
 import os
 import tempfile
 import pytest
 from pathlib import Path
+from unittest.mock import MagicMock
 from backend.database import init_db, get_connection
 
 @pytest.fixture
@@ -41,3 +43,26 @@ def db_conn(db_path):
 @pytest.fixture
 def sample_pdf_path():
     return str(Path(__file__).parent.parent / "test_documents" / "Receipt - esim.pdf")
+
+
+SAMPLE_LLM_RESPONSE = json.dumps({
+    "receipt_date": "2026-01-15", "document_title": "Tax Invoice", "vendor_name": "Office Depot",
+    "vendor_tax_id": "515234567", "vendor_receipt_id": "INV-2026-001", "client_name": None, "client_tax_id": None,
+    "description": "Office supplies purchase",
+    "line_items": [{"description": "Paper A4", "quantity": 5, "unit_price": 25.0}, {"description": "Ink cartridge", "quantity": 2, "unit_price": 89.0}],
+    "subtotal": 303.0, "tax_amount": 51.51, "total_amount": 354.51, "currency": "ILS",
+    "payment_method": "credit_card", "payment_identifier": "4580", "language": "he",
+    "additional_fields": [], "raw_extracted_text": "Office Depot\nTax Invoice\n...",
+    "document_type": "expense_receipt", "category": "office_supplies", "extraction_confidence": 0.95,
+})
+
+
+def mock_llm_response(content=SAMPLE_LLM_RESPONSE, finish_reason="stop"):
+    """Build a litellm-shaped mock response for extract_document tests."""
+    mock_response = MagicMock()
+    mock_response.choices = [MagicMock()]
+    mock_response.choices[0].message.content = content
+    mock_response.choices[0].finish_reason = finish_reason
+    mock_response.usage.prompt_tokens = 1000
+    mock_response.usage.completion_tokens = 500
+    return mock_response

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from backend.database import init_db, get_connection, _get_current_version
 
 def test_init_creates_tables(db_conn):
@@ -14,8 +15,11 @@ def test_wal_mode(db_conn):
     assert mode == "wal"
 
 def test_migration_version(db_conn):
+    # Derive from the migrations dir so this assert can't go stale when a
+    # migration is added (it sat at 5 while 006 and 007 landed).
+    migration_count = len(list((Path(__file__).parent.parent / "migrations").glob("*.sql")))
     version = _get_current_version(db_conn)
-    assert version == 5
+    assert version == migration_count
 
 def test_system_categories_seeded(db_conn):
     rows = db_conn.execute("SELECT name FROM categories WHERE is_system = 1 ORDER BY name").fetchall()

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -1,18 +1,11 @@
 import json
+import logging
 import pytest
-from unittest.mock import patch, MagicMock
-from backend.processing.extract import (build_extraction_prompt, parse_llm_response, extract_document, ExtractionResult)
+from unittest.mock import patch
+from backend.processing.extract import (build_extraction_prompt, parse_llm_response, extract_document)
+from tests.conftest import SAMPLE_LLM_RESPONSE, mock_llm_response
 
-SAMPLE_LLM_RESPONSE = json.dumps({
-    "receipt_date": "2026-01-15", "document_title": "Tax Invoice", "vendor_name": "Office Depot",
-    "vendor_tax_id": "515234567", "vendor_receipt_id": "INV-2026-001", "client_name": None, "client_tax_id": None,
-    "description": "Office supplies purchase",
-    "line_items": [{"description": "Paper A4", "quantity": 5, "unit_price": 25.0}, {"description": "Ink cartridge", "quantity": 2, "unit_price": 89.0}],
-    "subtotal": 303.0, "tax_amount": 51.51, "total_amount": 354.51, "currency": "ILS",
-    "payment_method": "credit_card", "payment_identifier": "4580", "language": "he",
-    "additional_fields": [], "raw_extracted_text": "Office Depot\nTax Invoice\n...",
-    "document_type": "expense_receipt", "category": "office_supplies", "extraction_confidence": 0.95,
-})
+EXTRACT_LOGGER = "backend.processing.extract"
 
 def test_build_prompt_includes_business_info():
     prompt = build_extraction_prompt(business_names=["Acme Corp", 'אקמה בע"מ'], business_addresses=["123 Main St", "רחוב ראשי 123"], business_tax_ids=["515000000"], expense_categories=[{"name": "office_supplies", "description": "Office equipment and supplies"}, {"name": "travel", "description": "Travel expenses"}], issued_categories=[])
@@ -39,6 +32,265 @@ def test_parse_invalid_json():
     with pytest.raises(ValueError, match="Failed to parse"):
         parse_llm_response("this is not json")
 
+
+# --- Tolerant parse ladder (issue #10) ---
+
+def test_parse_json_with_trailing_junk(caplog):
+    # Regression: docs #70 and #215 failed with "Extra data" on exactly this shape.
+    junk = "\n\nNote: the totals above were computed from the line items shown."
+    with caplog.at_level(logging.WARNING, logger=EXTRACT_LOGGER):
+        result = parse_llm_response(SAMPLE_LLM_RESPONSE + junk)
+    assert result.vendor_name == "Office Depot"
+    assert result.total_amount == 354.51
+    assert "trailing data" in caplog.text
+    assert "totals above were computed" in caplog.text  # snippet is logged
+
+
+def test_parse_json_with_trailing_whitespace_no_warning(caplog):
+    with caplog.at_level(logging.WARNING, logger=EXTRACT_LOGGER):
+        result = parse_llm_response(SAMPLE_LLM_RESPONSE + "\n\n   \n")
+    assert result.vendor_name == "Office Depot"
+    assert caplog.text == ""
+
+
+def test_parse_trailing_junk_with_fenced_block_does_not_hijack():
+    # A fenced example inside the trailing junk must not replace the real payload.
+    junk = '\nFor reference, a minimal example would be: ```json\n{"vendor_name": "WRONG"}\n```'
+    result = parse_llm_response(SAMPLE_LLM_RESPONSE + junk)
+    assert result.vendor_name == "Office Depot"
+
+
+def test_parse_fenced_json_with_junk_after_fence(caplog):
+    wrapped = f"```json\n{SAMPLE_LLM_RESPONSE}\n```\nThat concludes the extraction."
+    with caplog.at_level(logging.WARNING, logger=EXTRACT_LOGGER):
+        result = parse_llm_response(wrapped)
+    assert result.vendor_name == "Office Depot"
+    assert "concludes the extraction" in caplog.text
+
+
+def test_parse_fenced_json_with_backticks_in_payload(caplog):
+    # The old paired-fence regex truncated at the first closing ``` even when it
+    # appeared inside a JSON string value (e.g. OCR text of a code-snippet receipt).
+    data = json.loads(SAMPLE_LLM_RESPONSE)
+    data["raw_extracted_text"] = "Install with:\n```\nnpm install receiptory\n```\nThanks!"
+    wrapped = f"```json\n{json.dumps(data)}\n```"
+    with caplog.at_level(logging.WARNING, logger=EXTRACT_LOGGER):
+        result = parse_llm_response(wrapped)
+    assert "npm install receiptory" in result.raw_extracted_text
+    assert result.vendor_name == "Office Depot"
+    assert "trailing data" not in caplog.text  # bare closing fence is expected, not junk
+    assert "markdown fence" in caplog.text  # but the fence deviation itself is logged
+
+
+def test_parse_leading_prose_salvage(caplog):
+    with caplog.at_level(logging.WARNING, logger=EXTRACT_LOGGER):
+        result = parse_llm_response("Here is the extracted data:\n" + SAMPLE_LLM_RESPONSE)
+    assert result.vendor_name == "Office Depot"
+    assert "salvage" in caplog.text
+
+
+def test_parse_leading_prose_with_decoy_brace():
+    prose = "I'll return {fields} as JSON: "
+    result = parse_llm_response(prose + SAMPLE_LLM_RESPONSE)
+    assert result.vendor_name == "Office Depot"
+    assert result.total_amount == 354.51
+
+
+def test_parse_braces_but_no_valid_json():
+    with pytest.raises(ValueError, match="Failed to parse"):
+        parse_llm_response("set {x} to {y} please")
+
+
+def test_parse_non_dict_json_raises_value_error():
+    # raw_decode accepts any leading JSON value; a non-dict must not slip
+    # through and crash later with AttributeError on data.get().
+    with pytest.raises(ValueError, match="Failed to parse"):
+        parse_llm_response("2026 was a fine year")
+    with pytest.raises(ValueError, match="Failed to parse"):
+        parse_llm_response(json.dumps([1, 2, 3]))
+
+
+def test_parse_empty_and_whitespace_only():
+    with pytest.raises(ValueError, match="Failed to parse"):
+        parse_llm_response("")
+    with pytest.raises(ValueError, match="Failed to parse"):
+        parse_llm_response("   \n  ")
+
+
+def test_parse_fence_with_invalid_content_falls_through_to_salvage(caplog):
+    # A fence whose content isn't a JSON object must not end the ladder —
+    # a valid object later in the response is still salvaged.
+    text = "```\nthis is not json\n```\n" + SAMPLE_LLM_RESPONSE
+    with caplog.at_level(logging.WARNING, logger=EXTRACT_LOGGER):
+        result = parse_llm_response(text)
+    assert result.vendor_name == "Office Depot"
+    assert "salvage" in caplog.text
+
+
+def test_parse_array_wrapped_object_salvages_inner(caplog):
+    # Models occasionally wrap the payload in a one-element array; the
+    # salvage tier recovers the inner object.
+    wrapped = json.dumps([json.loads(SAMPLE_LLM_RESPONSE)])
+    with caplog.at_level(logging.WARNING, logger=EXTRACT_LOGGER):
+        result = parse_llm_response(wrapped)
+    assert result.vendor_name == "Office Depot"
+    assert "salvage" in caplog.text
+
+
+def test_parse_rejects_empty_object():
+    # json_object mode guarantees syntax, not shape — {} must fail loudly,
+    # not file an all-None record as processed.
+    with pytest.raises(ValueError, match="does not match the extraction schema"):
+        parse_llm_response("{}")
+
+
+def test_parse_rejects_line_item_fragment():
+    # A response truncated mid-document leaves complete inner line items;
+    # {"description", "quantity", "unit_price"} shares only ONE key with the
+    # schema and must not be salvaged as the whole document.
+    truncated = SAMPLE_LLM_RESPONSE[:SAMPLE_LLM_RESPONSE.index("}") + 1]
+    with pytest.raises(ValueError, match="Failed to parse"):
+        parse_llm_response(truncated)
+
+
+def test_parse_rejects_non_finite_and_out_of_range_numerics():
+    # Python's json accepts NaN/Infinity constants; NaN defeats comparison
+    # gates (NaN < x is False) and sqlite stores it as NULL. Booleans would
+    # coerce to 1.0. Out-of-range confidence (e.g. 95 meaning 95%) is unknown.
+    data = json.loads(SAMPLE_LLM_RESPONSE)
+    data.update({"extraction_confidence": "NaN", "total_amount": "Infinity", "subtotal": True})
+    result = parse_llm_response(json.dumps(data))
+    assert result.extraction_confidence is None
+    assert result.total_amount is None
+    assert result.subtotal is None
+    data = json.loads(SAMPLE_LLM_RESPONSE)
+    data["extraction_confidence"] = 95
+    result = parse_llm_response(json.dumps(data))
+    assert result.extraction_confidence is None
+
+
+def test_parse_survives_pathological_nesting():
+    # Deeply nested JSON raises RecursionError (not JSONDecodeError) inside
+    # the json module — the ladder must degrade to ValueError, not crash.
+    with pytest.raises(ValueError, match="Failed to parse"):
+        parse_llm_response("[" * 100000)
+
+
+def test_salvage_attempt_cap():
+    # 1000-candidate cap bounds CPU on brace-heavy garbage; just under the cap
+    # still salvages, past the cap fails loudly.
+    salvageable = "{x} " * 999 + SAMPLE_LLM_RESPONSE
+    assert parse_llm_response(salvageable).vendor_name == "Office Depot"
+    capped = "{x} " * 1001 + SAMPLE_LLM_RESPONSE
+    with pytest.raises(ValueError, match="Failed to parse"):
+        parse_llm_response(capped)
+
+
+def test_salvage_prefers_best_schema_match():
+    # A prose-embedded example object with SOME schema keys must not beat the
+    # real payload later in the response — most-keys wins, not first-found.
+    decoy = '{"vendor_name": "EXAMPLE Inc", "total_amount": 1.0}'
+    text = f"Example output: {decoy}\nActual data:\n{SAMPLE_LLM_RESPONSE}"
+    result = parse_llm_response(text)
+    assert result.vendor_name == "Office Depot"
+    assert result.total_amount == 354.51
+
+
+def test_fenced_decoy_does_not_beat_real_payload():
+    # A FENCED example object must compete on schema-key overlap like any
+    # other candidate — the fence tier must not short-circuit best-match.
+    text = ('Here is the format I will use: ```json\n{"vendor_name": "EXAMPLE Corp", "total_amount": 0.0}\n```\n'
+            f"Now the actual extraction:\n{SAMPLE_LLM_RESPONSE}")
+    result = parse_llm_response(text)
+    assert result.vendor_name == "Office Depot"
+    assert result.total_amount == 354.51
+
+
+def test_parse_coerces_line_item_numerics():
+    # NaN/string numbers inside line_items must be sanitized like the scalar
+    # money fields — a NaN unit_price serializes as invalid JSON downstream.
+    data = json.loads(SAMPLE_LLM_RESPONSE)
+    data["line_items"] = [{"description": "Paper", "quantity": "5", "unit_price": "NaN"}]
+    result = parse_llm_response(json.dumps(data))
+    assert result.line_items[0]["quantity"] == 5.0
+    assert result.line_items[0]["unit_price"] is None
+    data["line_items"] = "not a list"
+    result = parse_llm_response(json.dumps(data))
+    assert result.line_items == []
+
+
+def test_log_sanitization_strips_control_chars(caplog):
+    # ANSI escapes and NULs in LLM output must not reach the log stream
+    # (log forgery); tab/newline are deliberately preserved.
+    junk = "\nplain junk \x1b[31mred\x1b[0m and \x00 null"
+    with caplog.at_level(logging.WARNING, logger=EXTRACT_LOGGER):
+        parse_llm_response(SAMPLE_LLM_RESPONSE + junk)
+    assert "\x1b" not in caplog.text
+    assert "\x00" not in caplog.text
+    assert "plain junk" in caplog.text
+
+
+def test_salvaged_parse_without_confidence_skips_penalty(caplog):
+    # Salvage + missing confidence: no penalty math, confidence stays None
+    # (the pipeline routes None to needs_review).
+    data = json.loads(SAMPLE_LLM_RESPONSE)
+    del data["extraction_confidence"]
+    with caplog.at_level(logging.WARNING, logger=EXTRACT_LOGGER):
+        result = parse_llm_response("Here is the data:\n" + json.dumps(data))
+    assert result.extraction_confidence is None
+    assert result.parse_salvaged is True
+    assert "confidence penalized" not in caplog.text
+
+
+def test_parse_rejects_schema_less_object_with_trailing_payload():
+    # A decoy object sharing no extraction keys must not beat the real payload.
+    text = 'Example output: {"example": 1} and the actual data:\n' + SAMPLE_LLM_RESPONSE
+    result = parse_llm_response(text)
+    assert result.vendor_name == "Office Depot"
+    assert result.total_amount == 354.51
+
+
+def test_salvaged_parse_penalizes_confidence(caplog):
+    # T3 salvage = the model deviated from instructions; trust it 10% less.
+    with caplog.at_level(logging.WARNING, logger=EXTRACT_LOGGER):
+        result = parse_llm_response("Here is the extracted data:\n" + SAMPLE_LLM_RESPONSE)
+    assert result.extraction_confidence == pytest.approx(0.855)
+    assert "confidence penalized" in caplog.text
+
+
+def test_fenced_parse_penalizes_confidence():
+    # T2 (fenced despite instructions) carries the same penalty as T3.
+    result = parse_llm_response(f"```json\n{SAMPLE_LLM_RESPONSE}\n```")
+    assert result.extraction_confidence == pytest.approx(0.855)
+
+
+def test_direct_parse_keeps_full_confidence():
+    result = parse_llm_response(SAMPLE_LLM_RESPONSE)
+    assert result.extraction_confidence == 0.95
+
+
+def test_parse_coerces_string_numerics():
+    # json_object mode guarantees valid JSON, not types — a string "354.51"
+    # must not crash the pipeline's confidence gate or pollute REAL columns.
+    data = json.loads(SAMPLE_LLM_RESPONSE)
+    data.update({"total_amount": "354.51", "tax_amount": "51.51", "subtotal": "N/A", "extraction_confidence": "0.95"})
+    result = parse_llm_response(json.dumps(data))
+    assert result.total_amount == 354.51
+    assert result.tax_amount == 51.51
+    assert result.subtotal is None  # unparseable numeric degrades to None, not a crash
+    assert result.extraction_confidence == 0.95
+
+
+def test_parse_failure_logs_head_and_tail(caplog):
+    # The old text[:2000] truncation hid the "Extra data" at char 4846 (#215).
+    long_garbage = "HEAD_MARKER " + ("x" * 5000) + " TAIL_MARKER"
+    with caplog.at_level(logging.ERROR, logger=EXTRACT_LOGGER):
+        with pytest.raises(ValueError):
+            parse_llm_response(long_garbage)
+    assert "HEAD_MARKER" in caplog.text
+    assert "TAIL_MARKER" in caplog.text
+    assert "chars omitted" in caplog.text
+
 def test_document_type_override():
     response = json.loads(SAMPLE_LLM_RESPONSE)
     response["vendor_tax_id"] = "515000000"
@@ -47,17 +299,112 @@ def test_document_type_override():
 
 @patch("backend.processing.extract.litellm_completion")
 def test_extract_document_calls_llm(mock_completion):
-    mock_response = MagicMock()
-    mock_response.choices = [MagicMock()]
-    mock_response.choices[0].message.content = SAMPLE_LLM_RESPONSE
-    mock_response.usage.prompt_tokens = 1000
-    mock_response.usage.completion_tokens = 500
-    mock_completion.return_value = mock_response
+    mock_completion.return_value = mock_llm_response()
     result = extract_document(page_images=[b"fake-png-bytes"], model="gemini/gemini-3-flash-preview", api_key="test-key", business_names=["Acme"], business_addresses=["123 Main"], business_tax_ids=["515000000"], expense_categories=[{"name": "office_supplies", "description": "Office stuff"}], issued_categories=[{"name": "Tax Invoice", "description": "Standard invoice"}])
     assert result.extraction.vendor_name == "Office Depot"
     assert result.tokens_in == 1000
     assert result.tokens_out == 500
     mock_completion.assert_called_once()
+
+
+_EXTRACT_ARGS = dict(page_images=[b"fake-png-bytes"], model="gemini/gemini-3-flash-preview", api_key="test-key", business_names=["Acme"], business_addresses=["123 Main"], business_tax_ids=["515000000"], expense_categories=[{"name": "office_supplies", "description": "Office stuff"}], issued_categories=[])
+
+
+@patch("backend.processing.extract.litellm_completion")
+def test_extract_document_requests_json_mode(mock_completion):
+    mock_completion.return_value = mock_llm_response()
+    extract_document(**_EXTRACT_ARGS)
+    kwargs = mock_completion.call_args.kwargs
+    assert kwargs["response_format"] == {"type": "json_object"}
+    assert kwargs["drop_params"] is True
+
+
+@patch("backend.processing.extract.litellm_completion")
+def test_extract_document_json_mode_off(mock_completion):
+    mock_completion.return_value = mock_llm_response()
+    extract_document(**_EXTRACT_ARGS, json_mode=False)
+    kwargs = mock_completion.call_args.kwargs
+    assert "response_format" not in kwargs
+    assert "drop_params" not in kwargs
+
+
+@patch("backend.processing.extract.litellm_completion")
+def test_extract_document_truncated_response_raises(mock_completion):
+    mock_completion.return_value = mock_llm_response(content='{"vendor_name": "Off', finish_reason="length")
+    with pytest.raises(ValueError, match="truncated at max_tokens"):
+        extract_document(**_EXTRACT_ARGS)
+
+
+@patch("backend.processing.extract.litellm_completion")
+def test_extract_document_empty_response_raises(mock_completion):
+    mock_completion.return_value = mock_llm_response(content=None)
+    with pytest.raises(ValueError, match="empty response"):
+        extract_document(**_EXTRACT_ARGS)
+
+
+@patch("backend.processing.extract.litellm_completion")
+def test_extract_document_truncated_but_complete_object_salvaged(mock_completion):
+    # The issue #10 shape taken to the extreme: complete object, then rambling
+    # that hits the token cap. The ladder must salvage it, not hard-fail.
+    mock_completion.return_value = mock_llm_response(content=SAMPLE_LLM_RESPONSE + "\n\nrambling that ran into the cap", finish_reason="length")
+    result = extract_document(**_EXTRACT_ARGS)
+    assert result.extraction.vendor_name == "Office Depot"
+
+
+@patch("backend.processing.extract.litellm_completion")
+def test_extract_document_unparseable_non_truncated_reraises(mock_completion):
+    # Parse failure on a NON-truncated response must propagate the parse
+    # error unchanged, not get rewritten as a truncation error.
+    mock_completion.return_value = mock_llm_response(content="this is not json", finish_reason="stop")
+    with pytest.raises(ValueError, match="Failed to parse"):
+        extract_document(**_EXTRACT_ARGS)
+
+
+@patch("backend.processing.extract.litellm_completion")
+def test_extract_document_truncated_fragment_rejected(mock_completion):
+    # Truncated response whose only parseable object is an inner fragment:
+    # must raise the actionable truncation error, not file a junk record.
+    fragment = SAMPLE_LLM_RESPONSE[:SAMPLE_LLM_RESPONSE.index("}") + 1]
+    mock_completion.return_value = mock_llm_response(content=fragment, finish_reason="length")
+    with pytest.raises(ValueError, match="truncated at max_tokens"):
+        extract_document(**_EXTRACT_ARGS)
+
+
+@patch("backend.processing.extract.litellm_completion")
+def test_extract_document_truncated_salvaged_parse_rejected(mock_completion):
+    # Even a full-looking payload recovered via the SALVAGE tier is
+    # untrustworthy when the response was truncated — T1 only.
+    salvaged = "Here is the data:\n" + SAMPLE_LLM_RESPONSE
+    mock_completion.return_value = mock_llm_response(content=salvaged, finish_reason="length")
+    with pytest.raises(ValueError, match="truncated at max_tokens"):
+        extract_document(**_EXTRACT_ARGS)
+
+
+@patch("backend.processing.extract.litellm_completion")
+def test_extract_document_truncated_with_none_content(mock_completion):
+    # finish_reason=length with content=None must raise the truncation error,
+    # not a TypeError from slicing None.
+    mock_completion.return_value = mock_llm_response(content=None, finish_reason="length")
+    with pytest.raises(ValueError, match="truncated at max_tokens"):
+        extract_document(**_EXTRACT_ARGS)
+
+
+@patch("backend.processing.extract.litellm_completion")
+def test_extract_document_content_filter_reason_in_error(mock_completion):
+    # Gemini safety blocks arrive as finish_reason=content_filter with empty
+    # content — the stored error must carry the reason to be diagnosable.
+    mock_completion.return_value = mock_llm_response(content=None, finish_reason="content_filter")
+    with pytest.raises(ValueError, match="content_filter"):
+        extract_document(**_EXTRACT_ARGS)
+
+
+@patch("backend.processing.extract.litellm_completion")
+def test_extract_document_list_content_raises_cleanly(mock_completion):
+    # Some providers return content as a list of parts; guard against a
+    # cryptic AttributeError deep in the parser.
+    mock_completion.return_value = mock_llm_response(content=[{"type": "text", "text": "{}"}])
+    with pytest.raises(ValueError, match="unexpected content type"):
+        extract_document(**_EXTRACT_ARGS)
 
 
 def test_build_prompt_separates_expense_and_issued_categories():

--- a/tests/test_filing.py
+++ b/tests/test_filing.py
@@ -20,3 +20,27 @@ def test_special_chars_sanitized():
     name = generate_stored_filename(receipt_date="2026-01-15", vendor_receipt_id="INV/001:test", file_hash="abcdef1234567890")
     assert "/" not in name
     assert ":" not in name
+
+def test_malformed_date_falls_back():
+    # receipt_date is LLM-supplied — a non-YYYY-MM-DD value must not inject
+    # path separators into the filed filename.
+    name = generate_stored_filename(receipt_date="2026/01/15", vendor_receipt_id="R1", file_hash="abcdef1234567890")
+    assert name == "0000-00-00-R1-abcdef12.pdf"
+    name = generate_stored_filename(receipt_date="../../etc/passwd", vendor_receipt_id="R1", file_hash="abcdef1234567890")
+    assert "/" not in name and ".." not in name
+
+def test_non_string_values_fall_back():
+    # The LLM can emit the date or receipt id as a JSON number — must fall
+    # back cleanly, not TypeError inside the regex.
+    name = generate_stored_filename(receipt_date=20260115, vendor_receipt_id="R1", file_hash="abcdef1234567890")
+    assert name == "0000-00-00-R1-abcdef12.pdf"
+    name = generate_stored_filename(receipt_date="2026-01-15", vendor_receipt_id=12345, file_hash="abcdef1234567890")
+    assert name == "2026-01-15-000000-abcdef12.pdf"
+
+def test_date_regex_boundary_bypasses():
+    # $ matches before a trailing newline and \d matches Unicode digits —
+    # both must be rejected (fullmatch + ASCII-only pattern).
+    name = generate_stored_filename(receipt_date="2026-01-15\n", vendor_receipt_id="R1", file_hash="abcdef1234567890")
+    assert name == "0000-00-00-R1-abcdef12.pdf"
+    name = generate_stored_filename(receipt_date="٢٠٢٦-٠١-١٥", vendor_receipt_id="R1", file_hash="abcdef1234567890")
+    assert name == "0000-00-00-R1-abcdef12.pdf"

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,6 +1,6 @@
 import json
 import pytest
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch
 from backend.processing.pipeline import process_document
 from backend.database import get_connection
 from backend.config import set_setting, init_settings
@@ -68,3 +68,39 @@ def test_process_document_type_override(mock_extract, pending_doc, setup_db):
     with get_connection() as conn:
         doc = conn.execute("SELECT document_type FROM documents WHERE id = ?", (pending_doc,)).fetchone()
     assert doc["document_type"] == "issued_invoice"
+
+
+@patch("backend.processing.pipeline.extract_document")
+def test_process_document_missing_confidence_needs_review(mock_extract, pending_doc, setup_db):
+    # Missing confidence is not full confidence — route to a human.
+    no_conf = LLMExtractionResult(extraction=ExtractionResult(**{**MOCK_EXTRACTION.__dict__, "extraction_confidence": None}), tokens_in=1000, tokens_out=500, model="gemini/gemini-3-flash-preview")
+    mock_extract.return_value = no_conf
+    process_document(pending_doc, setup_db)
+    with get_connection() as conn:
+        doc = conn.execute("SELECT status FROM documents WHERE id = ?", (pending_doc,)).fetchone()
+    assert doc["status"] == "needs_review"
+
+
+@patch("backend.processing.pipeline.extract_document")
+def test_process_document_threads_json_mode_setting(mock_extract, pending_doc, setup_db):
+    set_setting("llm_json_mode", False)
+    mock_extract.return_value = MOCK_LLM_RESULT
+    process_document(pending_doc, setup_db)
+    assert mock_extract.call_args.kwargs["json_mode"] is False
+
+
+@patch("backend.processing.extract.litellm_completion")
+def test_process_document_with_trailing_junk_response(mock_completion, pending_doc, setup_db):
+    # End-to-end regression for issue #10 (docs #70/#215): the LLM emits a
+    # complete JSON object then keeps generating. The document must end up
+    # 'processed', not 'failed' — this patches the raw LLM call so the real
+    # parse ladder runs inside the pipeline.
+    from tests.conftest import SAMPLE_LLM_RESPONSE, mock_llm_response
+    mock_completion.return_value = mock_llm_response(content=SAMPLE_LLM_RESPONSE + "\n\nAs requested, all fields were extracted from the document image.")
+    process_document(pending_doc, setup_db)
+    with get_connection() as conn:
+        doc = conn.execute("SELECT status, vendor_name, total_amount, processing_error FROM documents WHERE id = ?", (pending_doc,)).fetchone()
+    assert doc["status"] == "processed"
+    assert doc["vendor_name"] == "Office Depot"
+    assert doc["total_amount"] == 354.51
+    assert doc["processing_error"] is None


### PR DESCRIPTION
## Summary

Fixes the top processing-failure class: Gemini 3 Flash intermittently keeps generating after emitting a complete JSON object (observed live: a stray closing brace), which failed the strict `json.loads` with "Extra data" (docs #70, #215 — 2 of 3 all-time failures).

**Parser (`fix(extract)`)**
- `parse_llm_response()` is now a tolerance ladder: leading-object `raw_decode` → best-match salvage (fence candidate + every `{` position compete on schema-key overlap; ≥2-key shape gate; 1000-candidate cap) → diagnosable failure with head **and** tail logged (the old `[:2000]` truncation hid the evidence at char 4846).
- Salvaged parses carry a 10% confidence penalty; decoy/example objects can't beat the real payload; truncated responses only accept a clean leading object and otherwise fail with an actionable "raise llm_max_tokens" error.
- LLM numerics hardened: string coercion, NaN/Infinity/bool rejection (NaN silently defeats comparison gates and binds as NULL in sqlite), out-of-range confidence → unknown, line-item numerics sanitized. Missing confidence now routes to `needs_review` instead of silently filing as `processed`.
- JSON mode at the source: `response_format={"type":"json_object"}` + `drop_params` on the litellm call, behind a new `llm_json_mode` setting (env `RECEIPTORY_LLM_JSON_MODE`, default on) so it can be disabled without an image rebuild. `finish_reason` (`length`, `content_filter`) is carried into stored errors. LLM-derived log text is sanitized against control-char forgery.

**Filing (`fix(filing)`)** — LLM-supplied `receipt_date`/`vendor_receipt_id` validated by type and shape (ASCII `fullmatch`); path separators, trailing newlines, Unicode digits, and JSON-number dates all fall back safely.

**Drift harness (`feat(scripts)`)** — `scripts/compare_json_mode.py`: stratified off-vs-on A/B over processed documents (the merge gate for enabling JSON mode). Ran on 18 docs: no systematic drift; the trailing-junk bug fired twice during the run and the new parser absorbed both.

**Test hygiene (`fix(tests)`)** — pre-existing stale `test_migration_version` now derives the expected version from `migrations/*.sql`.

**TODOS (`chore`)** — reorganized to canonical format (components, priorities, Completed section); new entries: typed `response_schema` experiment, pre-existing auth-401 test failure (P0).

## Test Coverage

45/45 audited paths covered (100%) after closing the one audit gap (non-truncated parse-error pass-through). 51 new tests across `test_extract.py`, `test_pipeline.py`, `test_filing.py`, `test_database.py`, shared helpers deduped into `conftest.py`.

<details><summary>Coverage diagram (audit at 44/45; gap E8 closed afterwards)</summary>

```
DOCUMENT UPLOAD → PROCESS PIPELINE (issue #10 hardening)
═════════════════════════════════════════════════════════
upload → status=pending → queue → _run_pipeline(doc)
  ├─ get_setting("llm_json_mode")  [✓ default + override]
  ▼
extract_document(json_mode=…)
  ├─ json_mode on → response_format+drop_params            [✓]
  ├─ json_mode off → params omitted                        [✓]
  ├─ empty content: length / stop / content_filter         [✓✓✓]
  ├─ non-string (list) content → clean error               [✓]
  ▼
parse_llm_response — tolerance ladder
  T1 clean / trailing junk / trailing whitespace / decoys  [✓✓✓✓]
  T2/T3 best-match salvage: fence, prose, array-wrap,
     fenced decoy, cap 999/1001, penalties, no-confidence  [✓ ×8]
  T4 shape gate ({} / line-item fragment), non-dict,
     empty, RecursionError, head+tail log, sanitizer       [✓ ×7]
  field handling: string/NaN/Inf/bool/range coercion,
     line-item numerics                                    [✓ ×3]
  truncation: fragment rejected, salvaged rejected,
     clean T1 accepted, non-truncated re-raise             [✓ ×4]
  ▼
pipeline gate: None→needs_review, <threshold, ≥threshold,
  E2E trailing-junk doc ends 'processed'                   [✓ ×4]
filing: valid / None / malformed / boundary / non-string   [✓ ×5]
```
</details>

## Pre-Landing Review

Three full review rounds at this HEAD (specialist army: testing, maintainability, security, performance + red team + adversarial, twice; plus a final adversarial pass on the last fixes). ~40 findings raised and resolved across the rounds — including three bugs the reviews caught in their own earlier fixes (NaN gate bypass, fenced-decoy bypass of best-match, TypeError on non-string dates). 0 unresolved. Review log: `clean`.

## Design Review

No frontend files changed — design review skipped.

## Eval Results

No prompt text changed. The LLM-behavior change (JSON mode) was gated by the off-vs-on drift comparison: 18 docs × 2 fresh extractions, field-level diffs were temperature-0 nondeterminism with no systematic direction; gate approved by owner. (~$0.05.)

## Scope Drift

Scope Check: CLEAN. TODOS.md reorganize (including entries from the parallel scanner workstream) was explicitly approved during ship. Excluded from the PR: `scripts/docaligner_*.py` spikes, `drift-report-issue10.txt` (contains receipt data).

## Plan Completion

Plan: [issue #10 locked implementation plan](https://github.com/LevMuchnik/Receiptory/issues/10#issuecomment-5020781550)

- [x] T1 4-tier parse ladder in `parse_llm_response()`
- [x] T2 unit tests 1–13 (all mapped, plus review-hardening extras)
- [x] T3 `response_format` + `drop_params` + `finish_reason` truncation check + tests
- [x] T4 drift script + 18-doc off-vs-on report; gate eyeballed and approved
- [x] T5 pipeline-level trailing-junk regression test
- [x] T6 ASCII ladder diagram (docstring)
- [ ] T7 post-deploy: reprocess docs #70 and #215 — **deferred by design, do after deploy**
- [x] T8 TODOS.md `response_schema` entry

Beyond plan (review-driven hardening): shape gate + best-match salvage, salvage confidence penalty, NaN/type guards, log sanitization, `llm_json_mode` setting, missing-confidence→needs_review, filing validation.

## Verification Results

Skipped pre-merge: the plan's verification step (T7) is post-deploy by design. Post-deploy checklist: reprocess documents #70 and #215 — both should extract successfully.

## TODOS

- TODOS.md reorganized to canonical format (components, Effort/Priority, Completed section).
- Added: "Typed response_schema structured output" (P2), "Fix pre-existing auth login test failure (401)" (P0).
- No existing TODO items completed by this PR.

## Documentation

- **CLAUDE.md**: Architecture Notes now describe the tolerant JSON parse ladder (strict parse → fence/salvage recovery); added an "LLM JSON handling" Key Design Decision covering the `llm_json_mode` setting (env `RECEIPTORY_LLM_JSON_MODE`, default true, litellm `drop_params` fallback), the salvage confidence penalty, missing-confidence → `needs_review`, and the `scripts/compare_json_mode.py` A/B harness; added `scripts/` to the project structure tree.
- **.env.example**: added `RECEIPTORY_LLM_JSON_MODE=true` to the LLM section.
- **README.md**: "All settings" → "Most settings are configurable via the admin UI" (`llm_json_mode` is env/db-only); added `scripts/` to the project structure tree.

- **Cross-model doc review** (post-ship `/document-release`): 3 stale claims fixed — CLAUDE.md now says needs_review triggers on missing OR below-threshold confidence; `.env.example` threshold comment corrected ("0 = never flag" no longer true); pre-existing stale system-category name (`not_a_receipt` → `uncategorized`, renamed in migration 005) fixed in CLAUDE.md. Left as-is: `docs/initial_specifications.md` (historical requirements record); `docs/claude-code-on-unraid.md` is not linked from README/CLAUDE.md (discoverability debt).

## Test plan

- [x] Full pytest suite: **220 passed**, 1 failed — the pre-existing `test_login_success` 401 (untouched by this branch, captured as P0 TODO; possibly container-env-specific)
- [x] Fresh verification run after every fix round (three green runs at 215/217/220)
- [ ] Post-deploy: reprocess docs #70 and #215

🤖 Generated with [Claude Code](https://claude.com/claude-code)

