### PR TITLE
fix: align LLM temperature config at 1.0 (#11)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,7 +17,7 @@
 # --- LLM (required) ---
 # RECEIPTORY_LLM_API_KEY=your-api-key-here
 # RECEIPTORY_LLM_MODEL=gemini/gemini-3-flash-preview
-# RECEIPTORY_LLM_TEMPERATURE=0.0        # 0 = deterministic
+# RECEIPTORY_LLM_TEMPERATURE=1.0        # Gemini 3 is tuned for temperature 1.0; lower values can degrade quality
 # RECEIPTORY_LLM_MAX_TOKENS=16384       # increase if JSON gets truncated
 # RECEIPTORY_LLM_JSON_MODE=true         # request JSON mode (response_format json_object); dropped on models without support
 # RECEIPTORY_LLM_SLEEP_INTERVAL=0.0     # seconds between LLM calls (rate limiting)

--- a/README.md
+++ b/README.md
@@ -283,9 +283,12 @@ uv run pytest tests/ -v
 
 ### Claude Code Dev Container
 
-A sidecar container for in-place development on UNRAID (no host installs needed):
+A sidecar container for in-place development on UNRAID (no host installs needed).
+Run these from the repo directory on the NAS (the `docker-compose.claude.yml` path is relative):
 
 ```bash
+cd /mnt/user/appdata/Receiptory
+
 # First run / after Dockerfile changes — rebuild then launch:
 docker compose -f docker-compose.claude.yml up -d --build && docker exec -it claude-dev claude-yolo
 

--- a/TODOS.md
+++ b/TODOS.md
@@ -46,6 +46,33 @@ Deferred items captured during planning and review. Organized by component, sort
 **Priority:** P2
 **Depends on:** Issue #10 shipped (json_object mode live and stable)
 
+## Ingestion
+
+### Harden url_triage JSON parsing (mirror extraction #10)
+
+**What:** Give the three `url_triage.py` LLM calls (`triage_telegram_urls`, `triage_email_urls`, `classify_email_documents`) the same JSON robustness extraction got in #10: `response_format={"type":"json_object"}` + `drop_params=True`, and reuse the tolerant parse ladder instead of a single strict `json.loads(_strip_code_fences(...))`.
+
+**Why:** Today a malformed/degenerate LLM response makes triage fall through to its fallback — `return list(urls)` / `return fallback` — which silently ingests ALL urls/documents, including junk. Extraction is protected against this; triage is not.
+
+**Pros:**
+- Closes the last unprotected LLM-parse path in the pipeline
+- Makes triage failure explicit (drop) rather than silent (ingest everything)
+- json_object mode also suppresses the class of litellm unsupported-param warnings that extraction avoids via `drop_params`
+
+**Cons:**
+- Touches a second subsystem's robustness — deliberately kept out of the temperature-alignment PR (issue #11) to stay right-sized
+- Needs its own tests for all three call sites (malformed response → correct fallback)
+- The tolerant ladder lives in `extract.py` (`parse_llm_response`) — sharing it means a small refactor to expose it
+
+**Context:**
+- Source: eng review of issue #11 (2026-07-20), tension 2 / deferred from the temperature work
+- Call sites + strict parse: `backend/ingestion/url_triage.py:67-78, 133-148, 215-231`
+- Reference implementation: extraction's json_mode + tolerant ladder in `backend/processing/extract.py` (see the `drop_params` comment at :304-311)
+
+**Effort:** M
+**Priority:** P2
+**Depends on:** None (independent of #11; can land any time)
+
 ## Scanner
 
 ### Expand test corpus + per-bucket tagging

--- a/backend/config.py
+++ b/backend/config.py
@@ -15,7 +15,7 @@ DEFAULTS: dict[str, Any] = {
     "reference_currency": "ILS",
     "llm_model": "gemini/gemini-3-flash-preview",
     "llm_api_key": "",
-    "llm_temperature": 0.0,
+    "llm_temperature": 1.0,
     "llm_max_tokens": 8192,
     "llm_json_mode": True,
     "llm_sleep_interval": 0.0,
@@ -88,7 +88,13 @@ def get_setting(key: str) -> Any:
     env_key = f"RECEIPTORY_{key.upper()}"
     env_val = os.environ.get(env_key)
     if env_val is not None and env_val != "":
-        return _parse_value(key, env_val)
+        # A malformed env override (bad number, invalid JSON list) must not crash
+        # callers, nor jump straight to the code default — precedence is env > db >
+        # default, so an unusable override is ignored and resolution continues.
+        try:
+            return _parse_value(key, env_val)
+        except ValueError:
+            logger.warning("Invalid env %s=%r; ignoring override, falling back to db/default", env_key, env_val)
     with get_connection() as conn:
         row = conn.execute("SELECT value FROM settings WHERE key = ?", (key,)).fetchone()
         if row is not None:

--- a/backend/ingestion/url_triage.py
+++ b/backend/ingestion/url_triage.py
@@ -37,6 +37,7 @@ async def triage_telegram_urls(message_text: str, urls: list[str]) -> list[str]:
 
     model = get_setting("llm_model")
     api_key = get_setting("llm_api_key")
+    temperature = get_setting("llm_temperature")
 
     if not model or not api_key:
         logger.warning("LLM not configured for URL triage, returning all URLs")
@@ -64,7 +65,7 @@ async def triage_telegram_urls(message_text: str, urls: list[str]) -> list[str]:
             model=model,
             api_key=api_key,
             messages=[{"role": "user", "content": prompt}],
-            temperature=0.0,
+            temperature=temperature,
         )
         raw = response.choices[0].message.content
         parsed = json.loads(_strip_code_fences(raw))
@@ -97,6 +98,7 @@ async def triage_email_urls(
     try:
         model = get_setting("llm_model")
         api_key = get_setting("llm_api_key")
+        temperature = get_setting("llm_temperature")
     except RuntimeError:
         logger.warning("Database not available for URL triage settings, returning all URLs")
         return fallback
@@ -135,7 +137,7 @@ async def triage_email_urls(
             model=model,
             api_key=api_key,
             messages=[{"role": "user", "content": prompt}],
-            temperature=0.0,
+            temperature=temperature,
         )
         raw = response.choices[0].message.content
         parsed = json.loads(_strip_code_fences(raw))
@@ -170,6 +172,7 @@ async def classify_email_documents(
     try:
         model = get_setting("llm_model")
         api_key = get_setting("llm_api_key")
+        temperature = get_setting("llm_temperature")
     except RuntimeError:
         logger.warning("Database not available for document classification settings, returning all")
         return fallback
@@ -217,7 +220,7 @@ async def classify_email_documents(
             model=model,
             api_key=api_key,
             messages=[{"role": "user", "content": content}],
-            temperature=0.0,
+            temperature=temperature,
         )
         raw = response.choices[0].message.content
         parsed = json.loads(_strip_code_fences(raw))

--- a/backend/processing/extract.py
+++ b/backend/processing/extract.py
@@ -294,7 +294,7 @@ def litellm_completion(**kwargs):
     return litellm.completion(**kwargs)
 
 
-def extract_document(page_images: list[bytes], model: str, api_key: str, business_names: list[str], business_addresses: list[str], business_tax_ids: list[str], expense_categories: list[dict[str, str]], issued_categories: list[dict[str, str]], temperature: float = 0.0, max_tokens: int = 8192, json_mode: bool = True) -> LLMExtractionResult:
+def extract_document(page_images: list[bytes], model: str, api_key: str, business_names: list[str], business_addresses: list[str], business_tax_ids: list[str], expense_categories: list[dict[str, str]], issued_categories: list[dict[str, str]], temperature: float = 1.0, max_tokens: int = 8192, json_mode: bool = True) -> LLMExtractionResult:
     prompt = build_extraction_prompt(business_names=business_names, business_addresses=business_addresses, business_tax_ids=business_tax_ids, expense_categories=expense_categories, issued_categories=issued_categories)
     content: list[dict] = [{"type": "text", "text": prompt}]
     for img_bytes in page_images:

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -40,11 +40,12 @@ function SectionCard({ title, icon, children, badge }: { title: string; icon: st
   );
 }
 
-function FieldGroup({ label, children }: { label: string; children: React.ReactNode }) {
+function FieldGroup({ label, children, hint }: { label: string; children: React.ReactNode; hint?: string }) {
   return (
     <div className="space-y-1.5">
       <Label className="text-[10px] font-bold text-muted-foreground uppercase tracking-wider block">{label}</Label>
       {children}
+      {hint && <p className="text-[11px] text-muted-foreground leading-snug">{hint}</p>}
     </div>
   );
 }
@@ -288,8 +289,8 @@ export default function SettingsPage() {
                   <FieldGroup label="API Key">
                     <Input className={inputCls} type="password" value={settings.llm_api_key || ""} onBlur={(e) => { if (e.target.value && !e.target.value.includes("***")) save({ llm_api_key: e.target.value }); }} onChange={(e) => setSettings({ ...settings, llm_api_key: e.target.value })} />
                   </FieldGroup>
-                  <FieldGroup label="Temperature (0 = deterministic)">
-                    <Input className={inputCls} type="number" step="0.1" min="0" max="2" value={settings.llm_temperature ?? 0} onBlur={(e) => save({ llm_temperature: parseFloat(e.target.value) })} onChange={(e) => setSettings({ ...settings, llm_temperature: e.target.value })} />
+                  <FieldGroup label="Temperature" hint="Gemini 3 is tuned for 1.0. Lower values can degrade extraction quality.">
+                    <Input className={inputCls} type="number" step="0.1" min="0" max="2" value={settings.llm_temperature ?? 1} onBlur={(e) => save({ llm_temperature: parseFloat(e.target.value) })} onChange={(e) => setSettings({ ...settings, llm_temperature: e.target.value })} />
                   </FieldGroup>
                   <FieldGroup label="Max Output Tokens">
                     <Input className={inputCls} type="number" step="1024" min="1024" max="32768" value={settings.llm_max_tokens ?? 8192} onBlur={(e) => save({ llm_max_tokens: parseInt(e.target.value) || 8192 })} onChange={(e) => setSettings({ ...settings, llm_max_tokens: e.target.value })} />

--- a/migrations/008_backfill_llm_temperature.sql
+++ b/migrations/008_backfill_llm_temperature.sql
@@ -1,0 +1,14 @@
+-- Issue #11: align llm_temperature default at 1.0.
+-- init_settings() persisted the old default (0.0) to the settings table on first
+-- run, and config precedence is env > db > default — so changing the DEFAULTS
+-- value alone is a no-op for existing installs (the stale db row wins). Rewrite
+-- rows still holding the old default so the realignment takes effect. Values are
+-- JSON-encoded (json.dumps(0.0) -> '0.0'); match both float and int encodings.
+-- Note: this cannot distinguish the auto-seeded default 0.0 from a user who
+-- deliberately chose 0.0 for deterministic extraction — both are reset to 1.0.
+-- Accepted for this single-user app (the schema has no is-default marker); any
+-- other custom temperature (e.g. 0.5) is left untouched.
+UPDATE settings
+SET value = '1.0',
+    updated_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now')
+WHERE key = 'llm_temperature' AND value IN ('0.0', '0');

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -7,6 +7,14 @@ def test_defaults_returned_when_no_db_value(db_path):
     assert get_setting("confidence_threshold") == 0.7
     assert get_setting("business_names") == []
 
+def test_llm_temperature_default_is_one(db_path):
+    # Issue #11: Gemini 3 is tuned for temperature 1.0; the default must reflect that.
+    assert get_setting("llm_temperature") == 1.0
+
+def test_init_settings_seeds_temperature_one(db_path):
+    init_settings()
+    assert get_setting("llm_temperature") == 1.0
+
 def test_set_and_get(db_path):
     set_setting("llm_model", "gpt-4o")
     assert get_setting("llm_model") == "gpt-4o"
@@ -19,6 +27,23 @@ def test_env_overrides_db(db_path, monkeypatch):
 def test_env_json_for_lists(db_path, monkeypatch):
     monkeypatch.setenv("RECEIPTORY_BUSINESS_NAMES", '["Acme", "אקמה"]')
     assert get_setting("business_names") == ["Acme", "אקמה"]
+
+def test_invalid_float_env_falls_back_to_default(db_path, monkeypatch):
+    # Issue #11: a malformed numeric env value must not crash callers (e.g. url_triage,
+    # extract) with ValueError — the override is ignored and resolution falls through.
+    monkeypatch.setenv("RECEIPTORY_LLM_TEMPERATURE", "not-a-number")
+    assert get_setting("llm_temperature") == 1.0
+
+def test_invalid_int_env_falls_back_to_default(db_path, monkeypatch):
+    monkeypatch.setenv("RECEIPTORY_LLM_MAX_TOKENS", "1,024")
+    assert get_setting("llm_max_tokens") == 8192
+
+def test_invalid_env_falls_through_to_db_value(db_path, monkeypatch):
+    # Precedence is env > db > default: a malformed env override is ignored, so the
+    # persisted DB value wins — NOT the code default.
+    set_setting("llm_temperature", 0.5)
+    monkeypatch.setenv("RECEIPTORY_LLM_TEMPERATURE", "not-a-number")
+    assert get_setting("llm_temperature") == 0.5
 
 def test_get_all_settings(db_path):
     from backend.config import get_all_settings

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -1,3 +1,4 @@
+import sqlite3
 from pathlib import Path
 from backend.database import init_db, get_connection, _get_current_version
 
@@ -47,3 +48,69 @@ def test_idempotent_migration(tmp_data_dir):
     with get_connection() as conn:
         count = conn.execute("SELECT COUNT(*) as c FROM categories").fetchone()["c"]
         assert count == 38  # 4 system + 27 expense + 7 issued
+
+
+def _run_migration_008(db):
+    sql = (Path(__file__).parent.parent / "migrations" / "008_backfill_llm_temperature.sql").read_text(encoding="utf-8")
+    db.executescript(sql)
+    db.commit()
+
+
+def test_migration_008_backfills_stale_temperature(tmp_path):
+    # Issue #11: the code default change is a no-op for existing installs (db > default),
+    # so this migration is the load-bearing part of the fix. It must rewrite the stale
+    # seeded default (0.0, and the int encoding 0) to 1.0 while leaving any custom value alone.
+    db = sqlite3.connect(str(tmp_path / "settings.db"))
+    db.executescript(
+        "CREATE TABLE settings (key TEXT PRIMARY KEY, value TEXT, "
+        "updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ','now')));"
+    )
+    db.execute("INSERT INTO settings (key, value) VALUES ('llm_temperature', '0.0')")
+    db.commit()
+
+    _run_migration_008(db)
+    assert db.execute("SELECT value FROM settings WHERE key='llm_temperature'").fetchone()[0] == "1.0"
+
+    # Int-encoded default (json.dumps(0)) also backfilled.
+    db.execute("UPDATE settings SET value='0' WHERE key='llm_temperature'")
+    db.commit()
+    _run_migration_008(db)
+    assert db.execute("SELECT value FROM settings WHERE key='llm_temperature'").fetchone()[0] == "1.0"
+
+    # A custom (non-zero) temperature is preserved.
+    db.execute("UPDATE settings SET value='0.5' WHERE key='llm_temperature'")
+    db.commit()
+    _run_migration_008(db)
+    assert db.execute("SELECT value FROM settings WHERE key='llm_temperature'").fetchone()[0] == "0.5"
+
+    # Idempotent: re-running after backfill leaves 1.0 untouched.
+    db.execute("UPDATE settings SET value='1.0' WHERE key='llm_temperature'")
+    db.commit()
+    _run_migration_008(db)
+    assert db.execute("SELECT value FROM settings WHERE key='llm_temperature'").fetchone()[0] == "1.0"
+    db.close()
+
+
+def test_migration_008_applies_through_runner_on_upgrade(tmp_path):
+    # Faithful upgrade path: an existing install sitting at schema_version 7 with a
+    # stale llm_temperature=0.0 row. The real runner must discover 008, parse its
+    # version, gate on schema_version, apply it exactly once, and rewrite 0.0 -> 1.0.
+    from backend.database import _run_migrations
+    db = sqlite3.connect(str(tmp_path / "upgrade.db"))
+    db.row_factory = sqlite3.Row
+    db.executescript(
+        "CREATE TABLE schema_version (version INTEGER PRIMARY KEY, "
+        "applied_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ','now')));"
+        "CREATE TABLE settings (key TEXT PRIMARY KEY, value TEXT NOT NULL, "
+        "updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ','now')));"
+    )
+    for v in range(1, 8):  # simulate migrations 001..007 already applied
+        db.execute("INSERT INTO schema_version (version) VALUES (?)", (v,))
+    db.execute("INSERT INTO settings (key, value) VALUES ('llm_temperature', '0.0')")
+    db.commit()
+
+    _run_migrations(db)  # discovers 008 (version 8 > current 7), applies once
+
+    assert db.execute("SELECT value FROM settings WHERE key='llm_temperature'").fetchone()["value"] == "1.0"
+    assert db.execute("SELECT COUNT(*) AS c FROM schema_version WHERE version=8").fetchone()["c"] == 1
+    db.close()

--- a/tests/test_email_classification.py
+++ b/tests/test_email_classification.py
@@ -8,6 +8,7 @@ def mock_llm_settings(monkeypatch):
     """Provide LLM settings for triage tests."""
     monkeypatch.setenv("RECEIPTORY_LLM_MODEL", "test-model")
     monkeypatch.setenv("RECEIPTORY_LLM_API_KEY", "test-key")
+    monkeypatch.setenv("RECEIPTORY_LLM_TEMPERATURE", "1.0")
 
 
 def _make_doc(identifier: str, source: str = "attachment", image: bytes = b"fake-png") -> ClassificationDocument:

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -329,6 +329,14 @@ def test_extract_document_json_mode_off(mock_completion):
 
 
 @patch("backend.processing.extract.litellm_completion")
+def test_extract_document_default_temperature_is_one(mock_completion):
+    # Issue #11: Gemini 3 is tuned for temperature 1.0 — the default must match.
+    mock_completion.return_value = mock_llm_response()
+    extract_document(**_EXTRACT_ARGS)
+    assert mock_completion.call_args.kwargs["temperature"] == 1.0
+
+
+@patch("backend.processing.extract.litellm_completion")
 def test_extract_document_truncated_response_raises(mock_completion):
     mock_completion.return_value = mock_llm_response(content='{"vendor_name": "Off', finish_reason="length")
     with pytest.raises(ValueError, match="truncated at max_tokens"):

--- a/tests/test_url_triage.py
+++ b/tests/test_url_triage.py
@@ -6,8 +6,27 @@ from unittest.mock import MagicMock, patch
 
 from backend.ingestion.url_triage import (
     triage_telegram_urls,
+    triage_email_urls,
+    classify_email_documents,
+    ClassificationDocument,
     _strip_code_fences,
 )
+
+# 1x1 transparent PNG, for classify_email_documents (needs first_page_image bytes).
+_PNG_1PX = (
+    b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01\x00\x00\x00\x01"
+    b"\x08\x06\x00\x00\x00\x1f\x15\xc4\x89\x00\x00\x00\nIDATx\x9cc\x00\x01"
+    b"\x00\x00\x05\x00\x01\r\n-\xb4\x00\x00\x00\x00IEND\xaeB`\x82"
+)
+
+
+def _stub_settings(key):
+    """get_setting stub returning correctly-typed values (temperature is numeric)."""
+    return {
+        "llm_model": "gpt-4o",
+        "llm_api_key": "test-key",
+        "llm_temperature": 0.5,
+    }.get(key, "test-key")
 
 
 def _make_llm_response(content: str):
@@ -46,7 +65,7 @@ class TestTriageTelegramUrls:
         )
 
         with patch("backend.ingestion.url_triage.litellm_completion", return_value=llm_response) as mock_llm, \
-             patch("backend.ingestion.url_triage.get_setting", side_effect=lambda k: "gpt-4o" if k == "llm_model" else "test-key"):
+             patch("backend.ingestion.url_triage.get_setting", side_effect=_stub_settings):
             result = await triage_telegram_urls("Here's my receipt", urls)
 
         assert result == ["https://store.example.com/receipt/12345"]
@@ -58,7 +77,7 @@ class TestTriageTelegramUrls:
         urls = ["https://a.com", "https://b.com"]
 
         with patch("backend.ingestion.url_triage.litellm_completion", side_effect=Exception("API error")), \
-             patch("backend.ingestion.url_triage.get_setting", side_effect=lambda k: "gpt-4o" if k == "llm_model" else "test-key"):
+             patch("backend.ingestion.url_triage.get_setting", side_effect=_stub_settings):
             result = await triage_telegram_urls("some text", urls)
 
         assert result == urls
@@ -88,7 +107,7 @@ class TestTriageTelegramUrls:
         )
 
         with patch("backend.ingestion.url_triage.litellm_completion", return_value=llm_response), \
-             patch("backend.ingestion.url_triage.get_setting", side_effect=lambda k: "gpt-4o" if k == "llm_model" else "test-key"):
+             patch("backend.ingestion.url_triage.get_setting", side_effect=_stub_settings):
             result = await triage_telegram_urls("text", urls)
 
         assert result == ["https://a.com"]
@@ -102,9 +121,38 @@ class TestTriageTelegramUrls:
         )
 
         with patch("backend.ingestion.url_triage.litellm_completion", return_value=llm_response), \
-             patch("backend.ingestion.url_triage.get_setting", side_effect=lambda k: "gpt-4o" if k == "llm_model" else "test-key"):
+             patch("backend.ingestion.url_triage.get_setting", side_effect=_stub_settings):
             result = await triage_telegram_urls("Invoice link", urls)
 
         assert result == ["https://invoice.example.com/dl/789"]
+
+
+class TestTemperatureFlowsToLLM:
+    """Issue #11: the configured llm_temperature must reach litellm at all 3 triage sites."""
+
+    @pytest.mark.asyncio
+    async def test_telegram_passes_temperature(self, db_path):
+        llm_response = _make_llm_response(json.dumps([]))
+        with patch("backend.ingestion.url_triage.litellm_completion", return_value=llm_response) as mock_llm, \
+             patch("backend.ingestion.url_triage.get_setting", side_effect=_stub_settings):
+            await triage_telegram_urls("text", ["https://a.com"])
+        assert mock_llm.call_args.kwargs["temperature"] == 0.5
+
+    @pytest.mark.asyncio
+    async def test_email_urls_passes_temperature(self, db_path):
+        llm_response = _make_llm_response(json.dumps([]))
+        with patch("backend.ingestion.url_triage.litellm_completion", return_value=llm_response) as mock_llm, \
+             patch("backend.ingestion.url_triage.get_setting", side_effect=_stub_settings):
+            await triage_email_urls("s@x.com", "subject", "body", ["https://a.com"])
+        assert mock_llm.call_args.kwargs["temperature"] == 0.5
+
+    @pytest.mark.asyncio
+    async def test_classify_documents_passes_temperature(self, db_path):
+        llm_response = _make_llm_response(json.dumps([]))
+        docs = [ClassificationDocument(identifier="a.pdf", source="attachment", first_page_image=_PNG_1PX)]
+        with patch("backend.ingestion.url_triage.litellm_completion", return_value=llm_response) as mock_llm, \
+             patch("backend.ingestion.url_triage.get_setting", side_effect=_stub_settings):
+            await classify_email_documents("s@x.com", "subject", "body", docs)
+        assert mock_llm.call_args.kwargs["temperature"] == 0.5
 
 


### PR DESCRIPTION
Closes #11.

## What
Aligns every LLM temperature config path at **1.0**. Gemini 3 Flash is tuned for temperature 1.0; Google warns that values below 1.0 can cause degraded reasoning and degeneration loops. Several paths still defaulted to or hardcoded `0.0`.

## Changes
- **`config.py`** — `DEFAULTS["llm_temperature"]` `0.0 → 1.0`, plus a guard so a malformed `RECEIPTORY_LLM_TEMPERATURE` env override is ignored (logged) and resolution falls through to db/default instead of crashing callers with `ValueError`.
- **`url_triage.py`** — all three `litellm_completion` call sites (`triage_telegram_urls`, `triage_email_urls`, `classify_email_documents`) now use `get_setting("llm_temperature")` instead of hardcoded `0.0`. These were the calls spamming the LiteLLM degeneration warning on every email ingestion.
- **`extract.py`** — `extract_document` temperature default `0.0 → 1.0` (fallback for direct callers; the pipeline already passes the setting).
- **`migrations/008_backfill_llm_temperature.sql`** — the load-bearing part for existing installs. `init_settings()` persisted the old `0.0` to the settings table, and precedence is env > db > default, so changing the code default alone is a no-op. This rewrites stale seeded rows (`0.0`/`0` → `1.0`) while leaving any custom value (e.g. `0.5`) untouched.
- **`.env.example` + `SettingsPage.tsx`** — drop the "0 = deterministic" nudge, cite the Gemini 3 recommendation.

## Acceptance criteria (from #11)
- ✅ Fresh install without the env var runs extraction **and** url triage at 1.0.
- ✅ `.env.example` and the Settings UI no longer recommend 0.
- ✅ url_triage no longer runs in the sub-1.0 regime Google warns about (kills the per-email LiteLLM warning).

## Tests
Full suite green: **232 passed**. New coverage:
- default resolves to 1.0 (`get_setting` + `init_settings` seed + `extract_document` default)
- configured temperature reaches litellm at all three triage sites
- migration 008 backfills `0.0`/`0`, preserves `0.5`, is idempotent, and applies through the real migration runner on a 7→8 upgrade
- malformed env override falls through to db value (precedence), not the code default

## Notes
- url_triage's JSON-parse hardening (mirroring #10) is intentionally **deferred** to a P2 TODO to keep this PR right-sized — it's independent of the temperature work.
- Includes a small unrelated README fix (dev-container run instructions) that was already in the working tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)