### PR TITLE
fix: retry LLM extraction on parse failure (#12)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,6 +20,7 @@
 # RECEIPTORY_LLM_TEMPERATURE=1.0        # Gemini 3 is tuned for temperature 1.0; lower values can degrade quality
 # RECEIPTORY_LLM_MAX_TOKENS=16384       # increase if JSON gets truncated
 # RECEIPTORY_LLM_JSON_MODE=true         # request JSON mode (response_format json_object); dropped on models without support
+# RECEIPTORY_LLM_PARSE_RETRIES=1        # retry the LLM call on unparseable responses before failing the doc; 0 = fail immediately
 # RECEIPTORY_LLM_SLEEP_INTERVAL=0.0     # seconds between LLM calls (rate limiting)
 # RECEIPTORY_CONFIDENCE_THRESHOLD=0.7   # 1 = flag everything; docs missing a confidence score are always flagged
 

--- a/TODOS.md
+++ b/TODOS.md
@@ -190,6 +190,22 @@ Deferred items captured during planning and review. Organized by component, sort
 **Priority:** P4
 **Depends on:** Fine-tune flywheel active, or a recurring need to compare many model versions
 
+## Observability
+
+### Persist `parse_retry_count` for LLM parse-retry visibility
+
+**What:** Add a persisted counter (e.g. `documents.parse_retry_count`) recording how many parse-retry attempts a document needed, surfaced in stats/UI.
+
+**Why:** Issue #12 adds a parse-failure retry loop that logs each retry at WARNING but stores nothing. If the model degrades and retries become common, there's no at-a-glance signal — you'd be grepping logs to notice. A stored counter turns "retries are happening" into a dashboard number.
+
+**Cons / why deferred:** Requires a schema migration + touching the large UPDATE in `pipeline.py:98` and the stats endpoints. Wider surface than the core fix warrants until retries prove common. The WARNING-per-retry log satisfies issue #12's acceptance criteria in the meantime.
+
+**Context:**
+- Raised by the outside voice during /plan-eng-review of issue #12 (2026-07-21).
+- Where to start: new numbered migration adding the column; increment it in `_run_pipeline`'s UPDATE alongside `processing_attempts`; expose in `backend/api/stats.py`.
+
+**Depends on:** Issue #12 (parse-retry loop) landing first.
+
 ## Completed
 
 _No completed items yet._

--- a/backend/config.py
+++ b/backend/config.py
@@ -18,6 +18,7 @@ DEFAULTS: dict[str, Any] = {
     "llm_temperature": 1.0,
     "llm_max_tokens": 8192,
     "llm_json_mode": True,
+    "llm_parse_retries": 1,
     "llm_sleep_interval": 0.0,
     "confidence_threshold": 0.7,
     "auth_username": "admin",

--- a/backend/processing/extract.py
+++ b/backend/processing/extract.py
@@ -11,6 +11,16 @@ import litellm
 logger = logging.getLogger(__name__)
 
 
+class ParseFailure(ValueError):
+    """Raised when the tolerant parse ladder cannot recover a document object
+    from the LLM response. Distinct from the plain ValueErrors extract_document
+    raises for truncation / empty / content-filter responses: only ParseFailure
+    is retryable (issue #12) — a garbage response is often transient at
+    temperature 1.0, whereas a max_tokens cutoff or a safety block will not
+    change on re-call. Subclasses ValueError so existing `except ValueError`
+    callers keep working."""
+
+
 @dataclass
 class ExtractionResult:
     receipt_date: str | None = None
@@ -113,6 +123,11 @@ _CONTROL_CHARS_RE = re.compile(r"[\x00-\x08\x0b-\x1f\x7f-\x9f]")  # keep \t and 
 _TRAILING_SNIPPET_CHARS = 500
 _FAILURE_LOG_CHARS = 2000
 _MAX_SALVAGE_ATTEMPTS = 1000
+# Safety cap on llm_parse_retries: retries are sequential paid LLM calls on the
+# single-process queue, so a misconfigured huge value would block the queue and
+# run up cost on one poison document. 5 is far above the transient-failure need
+# (issue #12 saw success on the first retry).
+_MAX_PARSE_RETRIES = 5
 
 
 def _sanitize_for_log(text: str) -> str:
@@ -246,7 +261,7 @@ def parse_llm_response(response_text: str) -> ExtractionResult:
             detail = str(e)
         else:
             detail = "leading JSON object does not match the extraction schema" if isinstance(value, dict) else "leading JSON value is not an object"
-        raise ValueError(f"Failed to parse LLM response as JSON: {detail}")
+        raise ParseFailure(f"Failed to parse LLM response as JSON: {detail}")
 
     data, trailing = decoded
     trailing = trailing.strip()
@@ -294,7 +309,7 @@ def litellm_completion(**kwargs):
     return litellm.completion(**kwargs)
 
 
-def extract_document(page_images: list[bytes], model: str, api_key: str, business_names: list[str], business_addresses: list[str], business_tax_ids: list[str], expense_categories: list[dict[str, str]], issued_categories: list[dict[str, str]], temperature: float = 1.0, max_tokens: int = 8192, json_mode: bool = True) -> LLMExtractionResult:
+def extract_document(page_images: list[bytes], model: str, api_key: str, business_names: list[str], business_addresses: list[str], business_tax_ids: list[str], expense_categories: list[dict[str, str]], issued_categories: list[dict[str, str]], temperature: float = 1.0, max_tokens: int = 8192, json_mode: bool = True, parse_retries: int = 0) -> LLMExtractionResult:
     prompt = build_extraction_prompt(business_names=business_names, business_addresses=business_addresses, business_tax_ids=business_tax_ids, expense_categories=expense_categories, issued_categories=issued_categories)
     content: list[dict] = [{"type": "text", "text": prompt}]
     for img_bytes in page_images:
@@ -309,37 +324,84 @@ def extract_document(page_images: list[bytes], model: str, api_key: str, busines
         # never brick extraction; the tolerant parser is the net.
         completion_kwargs["response_format"] = {"type": "json_object"}
         completion_kwargs["drop_params"] = True
-    response = litellm_completion(**completion_kwargs)
-    choice = response.choices[0]
-    raw_content = choice.message.content
-    finish_reason = getattr(choice, "finish_reason", None)
-    truncated = finish_reason == "length"
     truncation_error = f"LLM response truncated at max_tokens={max_tokens} — increase the llm_max_tokens setting"
-    if not raw_content:
-        if truncated:
-            raise ValueError(truncation_error)
-        # Gemini safety/recitation blocks arrive as finish_reason=content_filter
-        # with empty content — carry the reason so the stored error is diagnosable.
-        raise ValueError(f"LLM returned an empty response (finish_reason={finish_reason})")
-    if not isinstance(raw_content, str):
-        raise ValueError(f"LLM returned unexpected content type: {type(raw_content).__name__}")
-    logger.debug(f"LLM response ({response.usage.completion_tokens} tokens):\n{_sanitize_for_log(raw_content[:500])}")
+    # Retry the LLM call on PARSE failures only (issue #12). A single
+    # unparseable response is often transient at temperature 1.0 (doc #215
+    # re-ran clean 5/5). The retry loop must wrap the WHOLE block below so the
+    # ordering is unambiguous: truncation / empty / content-filter responses
+    # raise plain ValueError and propagate immediately (re-calling won't change
+    # a max_tokens cutoff or a safety block, only burn tokens), while only a
+    # non-truncated ParseFailure loops. litellm's own num_retries can't cover
+    # this — the HTTP call succeeded (200); it's the *content* our ladder can't
+    # parse. Tokens accumulate BEFORE each parse, so a doc that returns after a
+    # retry bills every attempt (including the failed parses) — processing_cost
+    # reflects the real spend on the SUCCESS path. On a hard-fail path
+    # (truncation/empty/content-type raises after one or more attempts) the
+    # accumulated totals are discarded, exactly as any failed doc records no
+    # cost today.
+    # Coerce and clamp the retry count. get_setting only runs the ENV override
+    # through _parse_value; a DB settings row returns raw json (could be a
+    # string "2", a float, or None), and range() is type-strict — so guard
+    # here rather than trust the caller. Negative -> 0 (an empty range would
+    # fall off the end returning None and crash the pipeline); over-large ->
+    # capped (see _MAX_PARSE_RETRIES).
     try:
-        extraction = parse_llm_response(raw_content)
-    except ValueError:
-        # A response that rambled into the token cap may still carry a
-        # complete leading object (the issue #10 shape) — only when the
-        # ladder can't recover one is truncation the actionable error.
+        retries = int(parse_retries)
+    except (TypeError, ValueError):
+        logger.warning(f"llm_parse_retries={parse_retries!r} is not an integer; treating as 0")
+        retries = 0
+    if retries < 0:
+        logger.warning(f"llm_parse_retries={retries} is negative; treating as 0")
+        retries = 0
+    if retries > _MAX_PARSE_RETRIES:
+        logger.warning(f"llm_parse_retries={retries} exceeds the cap; clamping to {_MAX_PARSE_RETRIES}")
+        retries = _MAX_PARSE_RETRIES
+    tokens_in_total = 0
+    tokens_out_total = 0
+    for attempt in range(retries + 1):
+        response = litellm_completion(**completion_kwargs)
+        usage = response.usage
+        tokens_in_total += getattr(usage, "prompt_tokens", 0) or 0
+        tokens_out_total += getattr(usage, "completion_tokens", 0) or 0
+        choice = response.choices[0]
+        raw_content = choice.message.content
+        finish_reason = getattr(choice, "finish_reason", None)
+        truncated = finish_reason == "length"
+        if not raw_content:
+            if truncated:
+                raise ValueError(truncation_error)
+            # Gemini safety/recitation blocks arrive as finish_reason=content_filter
+            # with empty content — carry the reason so the stored error is diagnosable.
+            raise ValueError(f"LLM returned an empty response (finish_reason={finish_reason})")
+        if not isinstance(raw_content, str):
+            raise ValueError(f"LLM returned unexpected content type: {type(raw_content).__name__}")
+        logger.debug(f"LLM response ({getattr(usage, 'completion_tokens', 0)} tokens):\n{_sanitize_for_log(raw_content[:500])}")
+        try:
+            extraction = parse_llm_response(raw_content)
+        except ParseFailure as e:
+            # A response that rambled into the token cap may still carry a
+            # complete leading object (the issue #10 shape) — only when the
+            # ladder can't recover one is truncation the actionable error.
+            # Truncation is deterministic, not transient: do NOT retry it.
+            if truncated:
+                logger.error(f"LLM response truncated at max_tokens={max_tokens} and no complete JSON object found. Tail:\n{_sanitize_for_log(raw_content[-_FAILURE_LOG_CHARS:])}")
+                raise ValueError(truncation_error)
+            # Non-truncated parse failure: retry if attempts remain, else fail
+            # the document with the last parse error (unchanged from today).
+            if attempt < retries:
+                logger.warning(f"LLM response parse failed (attempt {attempt + 1}/{retries + 1}), retrying: {e}")
+                continue
+            raise
         if truncated:
-            logger.error(f"LLM response truncated at max_tokens={max_tokens} and no complete JSON object found. Tail:\n{_sanitize_for_log(raw_content[-_FAILURE_LOG_CHARS:])}")
-            raise ValueError(truncation_error)
-        raise
-    if truncated:
-        # A T2/T3-salvaged parse of a TRUNCATED response is untrustworthy: the
-        # ladder may have latched onto an inner fragment (e.g. a line item) of
-        # the incomplete document. Only a clean leading object (T1) counts.
-        if extraction.parse_salvaged:
-            logger.error(f"LLM response truncated at max_tokens={max_tokens}; salvage tier matched only a fragment — rejecting. Tail:\n{_sanitize_for_log(raw_content[-_FAILURE_LOG_CHARS:])}")
-            raise ValueError(truncation_error)
-        logger.warning(f"LLM response hit max_tokens={max_tokens} but a complete leading JSON object was parsed")
-    return LLMExtractionResult(extraction=extraction, tokens_in=response.usage.prompt_tokens, tokens_out=response.usage.completion_tokens, model=model)
+            # A T2/T3-salvaged parse of a TRUNCATED response is untrustworthy: the
+            # ladder may have latched onto an inner fragment (e.g. a line item) of
+            # the incomplete document. Only a clean leading object (T1) counts.
+            if extraction.parse_salvaged:
+                logger.error(f"LLM response truncated at max_tokens={max_tokens}; salvage tier matched only a fragment — rejecting. Tail:\n{_sanitize_for_log(raw_content[-_FAILURE_LOG_CHARS:])}")
+                raise ValueError(truncation_error)
+            logger.warning(f"LLM response hit max_tokens={max_tokens} but a complete leading JSON object was parsed")
+        return LLMExtractionResult(extraction=extraction, tokens_in=tokens_in_total, tokens_out=tokens_out_total, model=model)
+    # Unreachable: retries is clamped >= 0 so the loop runs at least once, and
+    # each iteration returns or raises. Guard against a future edit that breaks
+    # that invariant rather than silently returning None.
+    raise RuntimeError("extract_document retry loop exited without returning")

--- a/backend/processing/pipeline.py
+++ b/backend/processing/pipeline.py
@@ -66,7 +66,8 @@ def _run_pipeline(doc_id: int, doc: dict, data_dir: str) -> None:
     temperature = get_setting("llm_temperature")
     max_tokens = get_setting("llm_max_tokens")
     json_mode = get_setting("llm_json_mode")
-    llm_result = extract_document(page_images=page_images, model=model, api_key=api_key, business_names=business_names, business_addresses=business_addresses, business_tax_ids=business_tax_ids, expense_categories=expense_categories, issued_categories=issued_categories, temperature=temperature, max_tokens=max_tokens, json_mode=json_mode)
+    parse_retries = get_setting("llm_parse_retries")
+    llm_result = extract_document(page_images=page_images, model=model, api_key=api_key, business_names=business_names, business_addresses=business_addresses, business_tax_ids=business_tax_ids, expense_categories=expense_categories, issued_categories=issued_categories, temperature=temperature, max_tokens=max_tokens, json_mode=json_mode, parse_retries=parse_retries)
     ext = llm_result.extraction
     doc_type = ext.document_type
     if ext.vendor_tax_id and ext.vendor_tax_id in business_tax_ids:

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -2,7 +2,7 @@ import json
 import logging
 import pytest
 from unittest.mock import patch
-from backend.processing.extract import (build_extraction_prompt, parse_llm_response, extract_document)
+from backend.processing.extract import (build_extraction_prompt, parse_llm_response, extract_document, ParseFailure, _MAX_PARSE_RETRIES)
 from tests.conftest import SAMPLE_LLM_RESPONSE, mock_llm_response
 
 EXTRACT_LOGGER = "backend.processing.extract"
@@ -366,6 +366,157 @@ def test_extract_document_unparseable_non_truncated_reraises(mock_completion):
     mock_completion.return_value = mock_llm_response(content="this is not json", finish_reason="stop")
     with pytest.raises(ValueError, match="Failed to parse"):
         extract_document(**_EXTRACT_ARGS)
+
+
+# --- Issue #12: retry LLM extraction on parse failure -----------------------
+#
+#   parse_retries=N  ── garbage ──► retry ──► valid ──► return (tokens summed)
+#                    └─ garbage ──► ... ──► garbage ──► raise last ParseFailure
+#   parse_retries=0  ── garbage ──► raise immediately (0 retries)
+#   truncated/empty  ── raise plain ValueError, NEVER retried (call_count == 1)
+
+
+@patch("backend.processing.extract.litellm_completion")
+def test_extract_document_retries_parse_failure_then_succeeds(mock_completion):
+    # Case 1 (AC): a garbage response followed by a valid one processes the
+    # document normally when a retry is allowed.
+    mock_completion.side_effect = [mock_llm_response(content="this is not json"), mock_llm_response()]
+    result = extract_document(**_EXTRACT_ARGS, parse_retries=1)
+    assert result.extraction.vendor_name == "Office Depot"
+    assert mock_completion.call_count == 2
+
+
+@patch("backend.processing.extract.litellm_completion")
+def test_extract_document_retries_exhausted_raises_last_parse_error(mock_completion):
+    # Case 2: retries exhausted -> the document fails with the parse error,
+    # exactly as today. N=1 means one original + one retry = 2 calls.
+    mock_completion.side_effect = [mock_llm_response(content="not json"), mock_llm_response(content="still not json")]
+    with pytest.raises(ParseFailure, match="Failed to parse"):
+        extract_document(**_EXTRACT_ARGS, parse_retries=1)
+    assert mock_completion.call_count == 2
+
+
+@patch("backend.processing.extract.litellm_completion")
+def test_extract_document_zero_retries_fails_immediately(mock_completion):
+    # Case 3 (AC): N=0 preserves current behavior — fail on the first parse
+    # failure with no retry.
+    mock_completion.side_effect = [mock_llm_response(content="not json"), mock_llm_response()]
+    with pytest.raises(ParseFailure, match="Failed to parse"):
+        extract_document(**_EXTRACT_ARGS, parse_retries=0)
+    assert mock_completion.call_count == 1
+
+
+@patch("backend.processing.extract.litellm_completion")
+def test_extract_document_accumulates_tokens_across_attempts(mock_completion):
+    # Case 4: tokens/cost must count ALL attempts (issue #12), including the
+    # failed parse. Each mock response reports 1000 in / 500 out.
+    mock_completion.side_effect = [mock_llm_response(content="not json"), mock_llm_response()]
+    result = extract_document(**_EXTRACT_ARGS, parse_retries=1)
+    assert result.tokens_in == 2000
+    assert result.tokens_out == 1000
+
+
+@patch("backend.processing.extract.litellm_completion")
+def test_extract_document_logs_warning_per_retry(mock_completion, caplog):
+    # Case 5: each retry is logged at WARNING with the attempt count.
+    mock_completion.side_effect = [mock_llm_response(content="not json"), mock_llm_response()]
+    with caplog.at_level(logging.WARNING, logger=EXTRACT_LOGGER):
+        extract_document(**_EXTRACT_ARGS, parse_retries=1)
+    assert "parse failed (attempt 1/2), retrying" in caplog.text
+
+
+@patch("backend.processing.extract.litellm_completion")
+def test_extract_document_truncated_response_not_retried(mock_completion):
+    # Case 6a: a truncated response is a max_tokens problem, not transient —
+    # it must fail fast without consuming a retry.
+    mock_completion.side_effect = [mock_llm_response(content='{"vendor_name": "Off', finish_reason="length"), mock_llm_response()]
+    with pytest.raises(ValueError, match="truncated at max_tokens"):
+        extract_document(**_EXTRACT_ARGS, parse_retries=1)
+    assert mock_completion.call_count == 1
+
+
+@patch("backend.processing.extract.litellm_completion")
+def test_extract_document_empty_response_not_retried(mock_completion):
+    # Case 6b: an empty (content-filter/safety-block) response must not retry —
+    # re-calling a blocked prompt only burns tokens.
+    mock_completion.side_effect = [mock_llm_response(content=None), mock_llm_response()]
+    with pytest.raises(ValueError, match="empty response"):
+        extract_document(**_EXTRACT_ARGS, parse_retries=1)
+    assert mock_completion.call_count == 1
+
+
+# --- Issue #12 (review hardening): parse_retries is coerced and clamped -------
+# A negative value would make range() empty -> the loop falls off the end and
+# returns None -> the pipeline crashes with a cryptic AttributeError. A non-int
+# (reachable via the DB settings path, which skips _parse_value) would raise
+# TypeError inside range(). A huge value would fire hundreds of paid LLM calls.
+
+
+@patch("backend.processing.extract.litellm_completion")
+def test_extract_document_negative_retries_clamped_to_zero(mock_completion):
+    # A negative config must degrade to "no retry", not silently return None.
+    mock_completion.side_effect = [mock_llm_response(content="not json"), mock_llm_response()]
+    with pytest.raises(ParseFailure, match="Failed to parse"):
+        extract_document(**_EXTRACT_ARGS, parse_retries=-3)
+    assert mock_completion.call_count == 1
+
+
+@patch("backend.processing.extract.litellm_completion")
+def test_extract_document_string_retries_coerced(mock_completion):
+    # The DB settings path can return a JSON string; extract_document must
+    # coerce it rather than blow up in range().
+    mock_completion.side_effect = [mock_llm_response(content="not json"), mock_llm_response()]
+    result = extract_document(**_EXTRACT_ARGS, parse_retries="1")
+    assert result.extraction.vendor_name == "Office Depot"
+    assert mock_completion.call_count == 2
+
+
+@patch("backend.processing.extract.litellm_completion")
+def test_extract_document_non_numeric_retries_treated_as_zero(mock_completion):
+    # A non-numeric junk value must not crash — treat as 0 retries.
+    mock_completion.side_effect = [mock_llm_response(content="not json"), mock_llm_response()]
+    with pytest.raises(ParseFailure, match="Failed to parse"):
+        extract_document(**_EXTRACT_ARGS, parse_retries="lots")
+    assert mock_completion.call_count == 1
+
+
+@patch("backend.processing.extract.litellm_completion")
+def test_extract_document_retries_capped(mock_completion):
+    # A huge config is clamped so one poison document can't fire unbounded
+    # sequential paid calls. Cap+1 attempts, then fail.
+    mock_completion.side_effect = [mock_llm_response(content="not json")] * (_MAX_PARSE_RETRIES + 5)
+    with pytest.raises(ParseFailure, match="Failed to parse"):
+        extract_document(**_EXTRACT_ARGS, parse_retries=999)
+    assert mock_completion.call_count == _MAX_PARSE_RETRIES + 1
+
+
+@patch("backend.processing.extract.litellm_completion")
+def test_extract_document_retry_then_truncated_raises_truncation(mock_completion):
+    # Retry interaction (review D2): a parse failure that RETRIES into a
+    # truncated response must surface the truncation error, not loop again —
+    # the retry consumed attempt 1, the truncation ends it at attempt 2.
+    mock_completion.side_effect = [
+        mock_llm_response(content="not json"),
+        mock_llm_response(content='{"vendor_name": "Off', finish_reason="length"),
+    ]
+    with pytest.raises(ValueError, match="truncated at max_tokens"):
+        extract_document(**_EXTRACT_ARGS, parse_retries=1)
+    assert mock_completion.call_count == 2
+
+
+@patch("backend.processing.extract.litellm_completion")
+def test_extract_document_salvaged_parse_on_retry_succeeds(mock_completion):
+    # Retry interaction (review D2): a salvage-tier (T2/T3) parse that succeeds
+    # on the retry attempt returns normally — salvage is only rejected when the
+    # response is ALSO truncated, which this one is not.
+    mock_completion.side_effect = [
+        mock_llm_response(content="not json"),
+        mock_llm_response(content="Sure! Here is the data:\n" + SAMPLE_LLM_RESPONSE),
+    ]
+    result = extract_document(**_EXTRACT_ARGS, parse_retries=1)
+    assert result.extraction.vendor_name == "Office Depot"
+    assert result.extraction.parse_salvaged is True
+    assert mock_completion.call_count == 2
 
 
 @patch("backend.processing.extract.litellm_completion")

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -89,6 +89,17 @@ def test_process_document_threads_json_mode_setting(mock_extract, pending_doc, s
     assert mock_extract.call_args.kwargs["json_mode"] is False
 
 
+@patch("backend.processing.pipeline.extract_document")
+def test_process_document_threads_parse_retries_setting(mock_extract, pending_doc, setup_db):
+    # Issue #12: the pipeline must forward llm_parse_retries into extract_document.
+    # A future edit dropping the kwarg would silently revert to 0 retries — this
+    # one-line assertion catches that wiring regression.
+    set_setting("llm_parse_retries", 3)
+    mock_extract.return_value = MOCK_LLM_RESULT
+    process_document(pending_doc, setup_db)
+    assert mock_extract.call_args.kwargs["parse_retries"] == 3
+
+
 @patch("backend.processing.extract.litellm_completion")
 def test_process_document_with_trailing_junk_response(mock_completion, pending_doc, setup_db):
     # End-to-end regression for issue #10 (docs #70/#215): the LLM emits a


### PR DESCRIPTION
Closes #12.

## Problem

A single unparseable LLM response permanently failed a document (`status='failed'`, manual retry required). The failure is transient at temperature 1.0 — re-running extraction on failed doc #215 succeeded 5/5 with identical settings. One automatic retry would have imported both #70 and #215 without user intervention.

## What changed

- **New setting `llm_parse_retries`** (env `RECEIPTORY_LLM_PARSE_RETRIES`, default **1**, `env > db > default` precedence via `config.py` DEFAULTS). Documented in `.env.example`.
- **Retry loop inside `extract_document()`** — retries the LLM call on parse failures only. `parse_llm_response()` now raises a dedicated **`ParseFailure(ValueError)`**; the loop catches only that. Truncation (`max_tokens`), empty responses, and Gemini `content_filter` safety blocks keep raising plain `ValueError` and fail fast — re-calling them only burns tokens.
- **Token accounting across attempts** — `tokens_in/out` accumulate *before* each parse, so `processing_cost_usd` reflects the full spend on the success path (a hard-fail discards totals, same as any failed doc today).

## Review hardening

The pre-landing review + two adversarial passes surfaced config edge cases, all fixed:

- Negative / non-int `parse_retries` (the DB settings path bypasses `_parse_value`, and `range()` is type-strict) → coerce + clamp to 0.
- Huge values → capped at `_MAX_PARSE_RETRIES = 5` so one poison doc can't fire hundreds of sequential paid calls on the single-process queue.
- Unreachable-guard after the loop so it can never silently return `None`.

## Why not litellm `num_retries`?

litellm retries transport failures (429/5xx/timeout). This failure is a **200 OK with unparseable content** — litellm sees success; our tolerant ladder sees garbage. Application-level retry is the right layer.

## Tests

14 cases: retry→success (N=1), exhaustion→last error, N=0 no-retry, token accumulation, per-retry WARNING, parse-only predicate (truncated/empty asserted `call_count==1`), config coerce/clamp/cap, retry+truncation interaction, salvage-on-retry, and pipeline wiring of the setting. Full suite: **246 passed / 0 failed**.

Related: #10 (tolerant parse), #11 (temperature 1.0). With all three, this failure mode should effectively disappear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)