### PR TITLE
feat(llm): reasoning-effort control + registry-driven cost/model info (#13)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,6 +21,7 @@
 # RECEIPTORY_LLM_MAX_TOKENS=16384       # increase if JSON gets truncated
 # RECEIPTORY_LLM_JSON_MODE=true         # request JSON mode (response_format json_object); dropped on models without support
 # RECEIPTORY_LLM_PARSE_RETRIES=1        # retry the LLM call on unparseable responses before failing the doc; 0 = fail immediately
+# RECEIPTORY_LLM_REASONING_EFFORT=none  # none|minimal|low|medium|high; sent only to reasoning-capable models. none = no reasoning param (identical to today). Higher = more reasoning/output tokens = more cost per doc
 # RECEIPTORY_LLM_SLEEP_INTERVAL=0.0     # seconds between LLM calls (rate limiting)
 # RECEIPTORY_CONFIDENCE_THRESHOLD=0.7   # 1 = flag everything; docs missing a confidence score are always flagged
 

--- a/backend/api/settings.py
+++ b/backend/api/settings.py
@@ -51,6 +51,50 @@ def test_llm(username: str = Depends(require_auth)):
         raise HTTPException(status_code=500, detail=f"LLM test failed: {e}")
 
 
+@router.get("/settings/model-info")
+def model_info(model: str | None = None, username: str = Depends(require_auth)):
+    """Economics + reasoning support for a single model, from litellm's registry
+    (issue #13). Drives the Settings LLM-Engine price line and the reasoning
+    control's enabled/disabled state. `model` defaults to the configured
+    llm_model. Prices are per 1M tokens for display; `in_registry` is false for
+    self-hosted / brand-new ids litellm can't resolve (the free-text case)."""
+    import litellm
+
+    model = model or get_setting("llm_model")
+    result = {
+        "model": model,
+        "in_registry": False,
+        "provider": None,
+        "supports_reasoning": False,
+        "input_price_per_1m": None,
+        "output_price_per_1m": None,
+        "max_output_tokens": None,
+    }
+    if not model:
+        return result
+
+    info = litellm.model_cost.get(model) or litellm.model_cost.get(model.split("/", 1)[-1])
+    if info:
+        result["in_registry"] = True
+        result["provider"] = info.get("litellm_provider")
+        result["max_output_tokens"] = info.get("max_output_tokens")
+        in_rate = info.get("input_cost_per_token")
+        out_rate = info.get("output_cost_per_token")
+        if in_rate is not None:
+            result["input_price_per_1m"] = round(in_rate * 1_000_000, 4)
+        if out_rate is not None:
+            result["output_price_per_1m"] = round(out_rate * 1_000_000, 4)
+
+    # supports_reasoning resolves even for some ids missing a model_cost row, so
+    # probe it independently of the price lookup.
+    try:
+        result["supports_reasoning"] = bool(litellm.supports_reasoning(model=model))
+    except Exception:
+        result["supports_reasoning"] = False
+
+    return result
+
+
 @router.get("/settings/telegram-status")
 async def telegram_status(username: str = Depends(require_auth)):
     """Check Telegram bot connection status."""

--- a/backend/api/settings.py
+++ b/backend/api/settings.py
@@ -73,7 +73,13 @@ def model_info(model: str | None = None, username: str = Depends(require_auth)):
     if not model:
         return result
 
-    info = litellm.model_cost.get(model) or litellm.model_cost.get(model.split("/", 1)[-1])
+    # get_model_info does proper provider resolution and raises for a model it
+    # can't map — safer than model_cost.get + prefix strip, which can land on a
+    # different-priced registry row (e.g. azure/deepseek-v4-pro -> deepseek-v4-pro).
+    try:
+        info = litellm.get_model_info(model)
+    except Exception:
+        info = None
     if info:
         result["in_registry"] = True
         result["provider"] = info.get("litellm_provider")

--- a/backend/config.py
+++ b/backend/config.py
@@ -19,6 +19,7 @@ DEFAULTS: dict[str, Any] = {
     "llm_max_tokens": 8192,
     "llm_json_mode": True,
     "llm_parse_retries": 1,
+    "llm_reasoning_effort": "none",
     "llm_sleep_interval": 0.0,
     "confidence_threshold": 0.7,
     "auth_username": "admin",

--- a/backend/ingestion/url_triage.py
+++ b/backend/ingestion/url_triage.py
@@ -7,7 +7,7 @@ import re
 from dataclasses import dataclass
 
 from backend.config import get_setting
-from backend.processing.extract import litellm_completion
+from backend.processing.extract import litellm_completion, reasoning_effort_kwargs
 
 logger = logging.getLogger(__name__)
 
@@ -38,6 +38,7 @@ async def triage_telegram_urls(message_text: str, urls: list[str]) -> list[str]:
     model = get_setting("llm_model")
     api_key = get_setting("llm_api_key")
     temperature = get_setting("llm_temperature")
+    reasoning_effort = get_setting("llm_reasoning_effort")
 
     if not model or not api_key:
         logger.warning("LLM not configured for URL triage, returning all URLs")
@@ -66,6 +67,7 @@ async def triage_telegram_urls(message_text: str, urls: list[str]) -> list[str]:
             api_key=api_key,
             messages=[{"role": "user", "content": prompt}],
             temperature=temperature,
+            **reasoning_effort_kwargs(model, reasoning_effort),
         )
         raw = response.choices[0].message.content
         parsed = json.loads(_strip_code_fences(raw))
@@ -99,6 +101,7 @@ async def triage_email_urls(
         model = get_setting("llm_model")
         api_key = get_setting("llm_api_key")
         temperature = get_setting("llm_temperature")
+        reasoning_effort = get_setting("llm_reasoning_effort")
     except RuntimeError:
         logger.warning("Database not available for URL triage settings, returning all URLs")
         return fallback
@@ -138,6 +141,7 @@ async def triage_email_urls(
             api_key=api_key,
             messages=[{"role": "user", "content": prompt}],
             temperature=temperature,
+            **reasoning_effort_kwargs(model, reasoning_effort),
         )
         raw = response.choices[0].message.content
         parsed = json.loads(_strip_code_fences(raw))
@@ -173,6 +177,7 @@ async def classify_email_documents(
         model = get_setting("llm_model")
         api_key = get_setting("llm_api_key")
         temperature = get_setting("llm_temperature")
+        reasoning_effort = get_setting("llm_reasoning_effort")
     except RuntimeError:
         logger.warning("Database not available for document classification settings, returning all")
         return fallback
@@ -221,6 +226,7 @@ async def classify_email_documents(
             api_key=api_key,
             messages=[{"role": "user", "content": content}],
             temperature=temperature,
+            **reasoning_effort_kwargs(model, reasoning_effort),
         )
         raw = response.choices[0].message.content
         parsed = json.loads(_strip_code_fences(raw))

--- a/backend/processing/extract.py
+++ b/backend/processing/extract.py
@@ -309,7 +309,54 @@ def litellm_completion(**kwargs):
     return litellm.completion(**kwargs)
 
 
-def extract_document(page_images: list[bytes], model: str, api_key: str, business_names: list[str], business_addresses: list[str], business_tax_ids: list[str], expense_categories: list[dict[str, str]], issued_categories: list[dict[str, str]], temperature: float = 1.0, max_tokens: int = 8192, json_mode: bool = True, parse_retries: int = 0) -> LLMExtractionResult:
+# Allowed reasoning-effort levels. "none" means "don't send the param" — the
+# byte-identical-to-today path (issue #13). The rest are the OpenAI-style scale
+# litellm translates per provider (Gemini thinkingBudget, Anthropic
+# thinking.budget_tokens, OpenAI reasoning_effort natively).
+REASONING_EFFORT_VALUES = ("none", "minimal", "low", "medium", "high")
+
+
+def normalize_reasoning_effort(raw: Any) -> str:
+    """Coerce an llm_reasoning_effort setting to a known value.
+
+    get_setting only runs the ENV override through _parse_value; a DB settings
+    row returns raw json (could be a string, None, or anything an old row held),
+    so validate at the use site rather than trust the caller — same pattern as
+    llm_parse_retries. Anything unrecognized collapses to "none" (param not
+    sent), so a bad value can never brick extraction, only fail safe to today's
+    behavior."""
+    if isinstance(raw, str):
+        v = raw.strip().lower()
+        if v in REASONING_EFFORT_VALUES:
+            return v
+    return "none"
+
+
+def reasoning_effort_kwargs(model: str, effort: Any) -> dict[str, Any]:
+    """Return litellm kwargs to request reasoning at `effort`, or {} to send
+    nothing.
+
+    Returns {} when effort is "none" OR the model can't reason — gating on
+    litellm.supports_reasoning keeps a non-reasoning model from raising
+    UnsupportedParamsError without relying on drop_params. When we DO inject the
+    param we also set drop_params=True so a reasoning model that rejects a
+    specific level (a provider that lacks "minimal", say) drops it rather than
+    erroring — the acceptance bar is "no UnsupportedParamsError in any
+    combination". drop_params is added ONLY on the inject path, so the effort==
+    "none" case stays byte-identical to today."""
+    value = normalize_reasoning_effort(effort)
+    if value == "none":
+        return {}
+    try:
+        if not litellm.supports_reasoning(model=model):
+            return {}
+    except Exception:
+        # Unknown model (not in the registry) — fail safe, don't send.
+        return {}
+    return {"reasoning_effort": value, "drop_params": True}
+
+
+def extract_document(page_images: list[bytes], model: str, api_key: str, business_names: list[str], business_addresses: list[str], business_tax_ids: list[str], expense_categories: list[dict[str, str]], issued_categories: list[dict[str, str]], temperature: float = 1.0, max_tokens: int = 8192, json_mode: bool = True, parse_retries: int = 0, reasoning_effort: Any = "none") -> LLMExtractionResult:
     prompt = build_extraction_prompt(business_names=business_names, business_addresses=business_addresses, business_tax_ids=business_tax_ids, expense_categories=expense_categories, issued_categories=issued_categories)
     content: list[dict] = [{"type": "text", "text": prompt}]
     for img_bytes in page_images:
@@ -324,6 +371,10 @@ def extract_document(page_images: list[bytes], model: str, api_key: str, busines
         # never brick extraction; the tolerant parser is the net.
         completion_kwargs["response_format"] = {"type": "json_object"}
         completion_kwargs["drop_params"] = True
+    # Reasoning effort (issue #13): merged in only for reasoning-capable models
+    # when the setting is not "none"; on the inject path this also flips
+    # drop_params=True (a no-op when json_mode already set it).
+    completion_kwargs.update(reasoning_effort_kwargs(model, reasoning_effort))
     truncation_error = f"LLM response truncated at max_tokens={max_tokens} — increase the llm_max_tokens setting"
     # Retry the LLM call on PARSE failures only (issue #12). A single
     # unparseable response is often transient at temperature 1.0 (doc #215

--- a/backend/processing/pipeline.py
+++ b/backend/processing/pipeline.py
@@ -67,7 +67,8 @@ def _run_pipeline(doc_id: int, doc: dict, data_dir: str) -> None:
     max_tokens = get_setting("llm_max_tokens")
     json_mode = get_setting("llm_json_mode")
     parse_retries = get_setting("llm_parse_retries")
-    llm_result = extract_document(page_images=page_images, model=model, api_key=api_key, business_names=business_names, business_addresses=business_addresses, business_tax_ids=business_tax_ids, expense_categories=expense_categories, issued_categories=issued_categories, temperature=temperature, max_tokens=max_tokens, json_mode=json_mode, parse_retries=parse_retries)
+    reasoning_effort = get_setting("llm_reasoning_effort")
+    llm_result = extract_document(page_images=page_images, model=model, api_key=api_key, business_names=business_names, business_addresses=business_addresses, business_tax_ids=business_tax_ids, expense_categories=expense_categories, issued_categories=issued_categories, temperature=temperature, max_tokens=max_tokens, json_mode=json_mode, parse_retries=parse_retries, reasoning_effort=reasoning_effort)
     ext = llm_result.extraction
     doc_type = ext.document_type
     if ext.vendor_tax_id and ext.vendor_tax_id in business_tax_ids:
@@ -119,6 +120,26 @@ def _run_pipeline(doc_id: int, doc: dict, data_dir: str) -> None:
 
 
 def estimate_cost(model: str, tokens_in: int, tokens_out: int) -> float:
-    pricing = {"gemini/gemini-3-flash-preview": (0.10, 0.40), "gpt-4o": (2.50, 10.00), "claude-sonnet-4-20250514": (3.00, 15.00)}
-    in_rate, out_rate = pricing.get(model, (1.0, 3.0))
-    return (tokens_in * in_rate + tokens_out * out_rate) / 1_000_000
+    """Cost in USD for a completion, from litellm's per-token registry so the
+    number stays correct when the model changes (issue #13). model_cost rates
+    are already per single token (not per million). Falls back to a generic
+    $1/$3-per-1M estimate when the model isn't in the registry (self-hosted,
+    brand-new, or a bare id litellm can't resolve) — same default the old
+    hardcoded table used for unknown models. Reasoning tokens are billed by the
+    provider as output tokens, so tokens_out already includes them."""
+    in_rate = out_rate = None
+    try:
+        import litellm
+        info = litellm.model_cost.get(model)
+        if info is None:
+            # Registry keys sometimes drop the provider prefix
+            # ("gemini/gemini-3-flash-preview" -> "gemini-3-flash-preview").
+            info = litellm.model_cost.get(model.split("/", 1)[-1])
+        if info:
+            in_rate = info.get("input_cost_per_token")
+            out_rate = info.get("output_cost_per_token")
+    except Exception:
+        logger.debug("litellm cost lookup failed for model %s; using fallback", model, exc_info=True)
+    if in_rate is None or out_rate is None:
+        return (tokens_in * 1.0 + tokens_out * 3.0) / 1_000_000
+    return tokens_in * in_rate + tokens_out * out_rate

--- a/backend/processing/pipeline.py
+++ b/backend/processing/pipeline.py
@@ -120,26 +120,19 @@ def _run_pipeline(doc_id: int, doc: dict, data_dir: str) -> None:
 
 
 def estimate_cost(model: str, tokens_in: int, tokens_out: int) -> float:
-    """Cost in USD for a completion, from litellm's per-token registry so the
-    number stays correct when the model changes (issue #13). model_cost rates
-    are already per single token (not per million). Falls back to a generic
-    $1/$3-per-1M estimate when the model isn't in the registry (self-hosted,
-    brand-new, or a bare id litellm can't resolve) — same default the old
-    hardcoded table used for unknown models. Reasoning tokens are billed by the
-    provider as output tokens, so tokens_out already includes them."""
-    in_rate = out_rate = None
+    """Cost in USD for a completion, via litellm's own price resolver so the
+    number stays correct when the model changes (issue #13). litellm.cost_per_token
+    does proper provider resolution (e.g. azure/*, bedrock/*) and RAISES for a
+    model it can't map — unlike a naive prefix strip, which can silently land on
+    a different-priced registry row. On any miss we fall back to a generic
+    $1/$3-per-1M estimate, the same default the old hardcoded table used for
+    unknown models. Reasoning tokens are billed by the provider as output tokens,
+    so tokens_out already includes them."""
     try:
         import litellm
-        info = litellm.model_cost.get(model)
-        if info is None:
-            # Registry keys sometimes drop the provider prefix
-            # ("gemini/gemini-3-flash-preview" -> "gemini-3-flash-preview").
-            info = litellm.model_cost.get(model.split("/", 1)[-1])
-        if info:
-            in_rate = info.get("input_cost_per_token")
-            out_rate = info.get("output_cost_per_token")
+        prompt_cost, completion_cost = litellm.cost_per_token(model=model, prompt_tokens=tokens_in, completion_tokens=tokens_out)
+        if prompt_cost is not None and completion_cost is not None:
+            return prompt_cost + completion_cost
     except Exception:
         logger.debug("litellm cost lookup failed for model %s; using fallback", model, exc_info=True)
-    if in_rate is None or out_rate is None:
-        return (tokens_in * 1.0 + tokens_out * 3.0) / 1_000_000
-    return tokens_in * in_rate + tokens_out * out_rate
+    return (tokens_in * 1.0 + tokens_out * 3.0) / 1_000_000

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -93,6 +93,19 @@ export default function SettingsPage() {
   const [gmailStatus, setGmailStatus] = useState<any>(null);
   const [gmailPollResult, setGmailPollResult] = useState<string | null>(null);
   const [notifyTestResult, setNotifyTestResult] = useState<string | null>(null);
+  const [modelInfo, setModelInfo] = useState<any>(null);
+
+  // Look up price + reasoning support for the current model (issue #13).
+  // Debounced so typing into the free-text model field doesn't fire a request
+  // per keystroke against the ~3k-entry registry.
+  useEffect(() => {
+    const model = settings.llm_model;
+    if (!model) { setModelInfo(null); return; }
+    const t = setTimeout(() => {
+      api.get(`/settings/model-info?model=${encodeURIComponent(model)}`).then(setModelInfo).catch(() => setModelInfo(null));
+    }, 400);
+    return () => clearTimeout(t);
+  }, [settings.llm_model]);
 
   useEffect(() => {
     api.get("/settings").then(setSettings);
@@ -285,6 +298,22 @@ export default function SettingsPage() {
                 <div className="space-y-4">
                   <FieldGroup label="Extraction Model">
                     <Input className={inputCls} value={settings.llm_model || ""} onBlur={(e) => save({ llm_model: e.target.value })} onChange={(e) => setSettings({ ...settings, llm_model: e.target.value })} placeholder="gpt-4o" />
+                    {modelInfo && modelInfo.model === settings.llm_model && (
+                      <div className="flex flex-wrap items-center gap-1.5 pt-0.5">
+                        {modelInfo.in_registry ? (
+                          <span className="text-[11px] text-muted-foreground font-mono">
+                            {modelInfo.input_price_per_1m != null && modelInfo.output_price_per_1m != null
+                              ? `$${modelInfo.input_price_per_1m} / $${modelInfo.output_price_per_1m} per 1M tokens`
+                              : "price unavailable"}
+                          </span>
+                        ) : (
+                          <span className="text-[11px] text-muted-foreground">Not in litellm registry — used as-is</span>
+                        )}
+                        <span className={`text-[10px] font-bold px-1.5 py-0.5 rounded ${modelInfo.supports_reasoning ? "bg-[#7bf8a1]/30 text-[#007239]" : "bg-muted text-muted-foreground"}`}>
+                          {modelInfo.supports_reasoning ? "reasoning" : "no reasoning"}
+                        </span>
+                      </div>
+                    )}
                   </FieldGroup>
                   <FieldGroup label="API Key">
                     <Input className={inputCls} type="password" value={settings.llm_api_key || ""} onBlur={(e) => { if (e.target.value && !e.target.value.includes("***")) save({ llm_api_key: e.target.value }); }} onChange={(e) => setSettings({ ...settings, llm_api_key: e.target.value })} />
@@ -294,6 +323,27 @@ export default function SettingsPage() {
                   </FieldGroup>
                   <FieldGroup label="Max Output Tokens">
                     <Input className={inputCls} type="number" step="1024" min="1024" max="32768" value={settings.llm_max_tokens ?? 8192} onBlur={(e) => save({ llm_max_tokens: parseInt(e.target.value) || 8192 })} onChange={(e) => setSettings({ ...settings, llm_max_tokens: e.target.value })} />
+                  </FieldGroup>
+                  <FieldGroup
+                    label="Reasoning Effort"
+                    hint={
+                      modelInfo && modelInfo.model === settings.llm_model && !modelInfo.supports_reasoning
+                        ? "The selected model does not support reasoning. Effort is ignored."
+                        : "Higher effort spends more reasoning (output) tokens per document, raising cost. \"None\" sends no reasoning parameter."
+                    }
+                  >
+                    <select
+                      className={`${inputCls} w-full px-3 disabled:opacity-50 disabled:cursor-not-allowed`}
+                      value={typeof settings.llm_reasoning_effort === "string" ? settings.llm_reasoning_effort : "none"}
+                      disabled={!!(modelInfo && modelInfo.model === settings.llm_model && !modelInfo.supports_reasoning)}
+                      onChange={(e) => { setSettings({ ...settings, llm_reasoning_effort: e.target.value }); save({ llm_reasoning_effort: e.target.value }); }}
+                    >
+                      <option value="none">None (default)</option>
+                      <option value="minimal">Minimal</option>
+                      <option value="low">Low</option>
+                      <option value="medium">Medium</option>
+                      <option value="high">High</option>
+                    </select>
                   </FieldGroup>
                   <FieldGroup label="Sleep Between Calls (seconds)">
                     <Input className={inputCls} type="number" step="0.1" value={settings.llm_sleep_interval ?? ""} onBlur={(e) => save({ llm_sleep_interval: parseFloat(e.target.value) })} onChange={(e) => setSettings({ ...settings, llm_sleep_interval: e.target.value })} />

--- a/tests/test_email_classification.py
+++ b/tests/test_email_classification.py
@@ -9,6 +9,7 @@ def mock_llm_settings(monkeypatch):
     monkeypatch.setenv("RECEIPTORY_LLM_MODEL", "test-model")
     monkeypatch.setenv("RECEIPTORY_LLM_API_KEY", "test-key")
     monkeypatch.setenv("RECEIPTORY_LLM_TEMPERATURE", "1.0")
+    monkeypatch.setenv("RECEIPTORY_LLM_REASONING_EFFORT", "none")
 
 
 def _make_doc(identifier: str, source: str = "attachment", image: bytes = b"fake-png") -> ClassificationDocument:

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -566,6 +566,71 @@ def test_extract_document_list_content_raises_cleanly(mock_completion):
         extract_document(**_EXTRACT_ARGS)
 
 
+# --- Reasoning effort (issue #13) ---
+
+from backend.processing.extract import normalize_reasoning_effort, reasoning_effort_kwargs
+
+_EXTRACT_ARGS_NO_MODEL = {k: v for k, v in _EXTRACT_ARGS.items() if k != "model"}
+
+
+@pytest.mark.parametrize("raw,expected", [
+    ("high", "high"), ("HIGH", "high"), (" low ", "low"), ("medium", "medium"),
+    ("minimal", "minimal"), ("none", "none"),
+    ("bogus", "none"), ("", "none"), (None, "none"), (5, "none"), (["high"], "none"),
+])
+def test_normalize_reasoning_effort(raw, expected):
+    assert normalize_reasoning_effort(raw) == expected
+
+
+def test_reasoning_effort_kwargs_supporting_model():
+    assert reasoning_effort_kwargs("gemini/gemini-3-flash-preview", "high") == {"reasoning_effort": "high", "drop_params": True}
+
+
+def test_reasoning_effort_kwargs_none_sends_nothing():
+    assert reasoning_effort_kwargs("gemini/gemini-3-flash-preview", "none") == {}
+
+
+def test_reasoning_effort_kwargs_nonreasoning_model_sends_nothing():
+    assert reasoning_effort_kwargs("gpt-4o", "high") == {}
+
+
+def test_reasoning_effort_kwargs_unknown_model_sends_nothing():
+    assert reasoning_effort_kwargs("some/unknown-model-xyz", "high") == {}
+
+
+@patch("backend.processing.extract.litellm_completion")
+def test_extract_document_no_reasoning_by_default(mock_completion):
+    # Default (none) must be byte-identical to today: no reasoning_effort sent.
+    mock_completion.return_value = mock_llm_response()
+    extract_document(**_EXTRACT_ARGS)
+    assert "reasoning_effort" not in mock_completion.call_args.kwargs
+
+
+@patch("backend.processing.extract.litellm_completion")
+def test_extract_document_reasoning_effort_on_supporting_model(mock_completion):
+    mock_completion.return_value = mock_llm_response()
+    extract_document(**_EXTRACT_ARGS, reasoning_effort="high")
+    kwargs = mock_completion.call_args.kwargs
+    assert kwargs["reasoning_effort"] == "high"
+    assert kwargs["drop_params"] is True
+
+
+@patch("backend.processing.extract.litellm_completion")
+def test_extract_document_reasoning_effort_skipped_on_nonreasoning_model(mock_completion):
+    # gpt-4o can't reason: the param must be withheld so litellm never raises
+    # UnsupportedParamsError, even when the user set an effort level.
+    mock_completion.return_value = mock_llm_response()
+    extract_document(**_EXTRACT_ARGS_NO_MODEL, model="gpt-4o", reasoning_effort="high")
+    assert "reasoning_effort" not in mock_completion.call_args.kwargs
+
+
+@patch("backend.processing.extract.litellm_completion")
+def test_extract_document_invalid_reasoning_effort_ignored(mock_completion):
+    mock_completion.return_value = mock_llm_response()
+    extract_document(**_EXTRACT_ARGS, reasoning_effort="turbo")
+    assert "reasoning_effort" not in mock_completion.call_args.kwargs
+
+
 def test_build_prompt_separates_expense_and_issued_categories():
     prompt = build_extraction_prompt(
         business_names=["Acme"],

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -100,6 +100,37 @@ def test_process_document_threads_parse_retries_setting(mock_extract, pending_do
     assert mock_extract.call_args.kwargs["parse_retries"] == 3
 
 
+@patch("backend.processing.pipeline.extract_document")
+def test_process_document_threads_reasoning_effort_setting(mock_extract, pending_doc, setup_db):
+    # Issue #13: the pipeline must forward llm_reasoning_effort into
+    # extract_document. Dropping the kwarg would silently revert to "none".
+    set_setting("llm_reasoning_effort", "high")
+    mock_extract.return_value = MOCK_LLM_RESULT
+    process_document(pending_doc, setup_db)
+    assert mock_extract.call_args.kwargs["reasoning_effort"] == "high"
+
+
+def test_estimate_cost_uses_registry():
+    from backend.processing.pipeline import estimate_cost
+    # gpt-4o is $2.50 / $10.00 per 1M in litellm's registry.
+    assert estimate_cost("gpt-4o", 1000, 2000) == pytest.approx((1000 * 2.50 + 2000 * 10.00) / 1_000_000)
+
+
+def test_estimate_cost_strips_provider_prefix():
+    from backend.processing.pipeline import estimate_cost
+    # Provider-prefixed id must resolve to the same cost as the bare id.
+    assert estimate_cost("gemini/gemini-3-flash-preview", 1000, 2000) == pytest.approx(
+        estimate_cost("gemini-3-flash-preview", 1000, 2000)
+    )
+    assert estimate_cost("gemini/gemini-3-flash-preview", 1000, 2000) > 0
+
+
+def test_estimate_cost_unknown_model_falls_back():
+    from backend.processing.pipeline import estimate_cost
+    # Unknown model -> generic $1 / $3 per 1M, matching the old default tuple.
+    assert estimate_cost("totally/unknown-model", 1000, 2000) == pytest.approx((1000 * 1.0 + 2000 * 3.0) / 1_000_000)
+
+
 @patch("backend.processing.extract.litellm_completion")
 def test_process_document_with_trailing_junk_response(mock_completion, pending_doc, setup_db):
     # End-to-end regression for issue #10 (docs #70/#215): the LLM emits a

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -116,19 +116,29 @@ def test_estimate_cost_uses_registry():
     assert estimate_cost("gpt-4o", 1000, 2000) == pytest.approx((1000 * 2.50 + 2000 * 10.00) / 1_000_000)
 
 
-def test_estimate_cost_strips_provider_prefix():
+def test_estimate_cost_resolves_provider_prefixed_model():
     from backend.processing.pipeline import estimate_cost
-    # Provider-prefixed id must resolve to the same cost as the bare id.
-    assert estimate_cost("gemini/gemini-3-flash-preview", 1000, 2000) == pytest.approx(
-        estimate_cost("gemini-3-flash-preview", 1000, 2000)
-    )
+    # litellm resolves the provider-prefixed id to a real, non-zero price.
     assert estimate_cost("gemini/gemini-3-flash-preview", 1000, 2000) > 0
 
 
 def test_estimate_cost_unknown_model_falls_back():
     from backend.processing.pipeline import estimate_cost
-    # Unknown model -> generic $1 / $3 per 1M, matching the old default tuple.
+    # Unmappable model -> litellm.cost_per_token raises -> generic $1 / $3 per 1M,
+    # matching the old default tuple. Guards the wrong-price collision that a naive
+    # prefix strip caused (azure/* landing on a cheaper bare registry row).
     assert estimate_cost("totally/unknown-model", 1000, 2000) == pytest.approx((1000 * 1.0 + 2000 * 3.0) / 1_000_000)
+
+
+def test_estimate_cost_falls_back_when_resolver_raises(monkeypatch):
+    import litellm
+    from backend.processing import pipeline
+    # Any resolver failure (unmapped model, partial-cost row, litellm internals)
+    # must fall back to the generic estimate rather than crash the pipeline.
+    def boom(*a, **k):
+        raise Exception("This model isn't mapped yet")
+    monkeypatch.setattr(litellm, "cost_per_token", boom)
+    assert pipeline.estimate_cost("some/model", 1000, 2000) == pytest.approx((1000 * 1.0 + 2000 * 3.0) / 1_000_000)
 
 
 @patch("backend.processing.extract.litellm_completion")

--- a/tests/test_settings_api.py
+++ b/tests/test_settings_api.py
@@ -39,3 +39,43 @@ def test_queue_status(authed_client):
     resp = authed_client.get("/api/queue/status")
     assert resp.status_code == 200
     assert "pending" in resp.json()
+
+
+def test_model_info_registry_hit(authed_client):
+    # A known model resolves: in registry, priced, reasoning flag populated (#13).
+    resp = authed_client.get("/api/settings/model-info?model=gpt-4o")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["model"] == "gpt-4o"
+    assert data["in_registry"] is True
+    assert data["input_price_per_1m"] is not None
+    assert data["output_price_per_1m"] is not None
+    assert data["supports_reasoning"] is False  # gpt-4o is not a reasoning model
+
+
+def test_model_info_reasoning_model(authed_client):
+    resp = authed_client.get("/api/settings/model-info?model=gemini/gemini-3-flash-preview")
+    assert resp.status_code == 200
+    assert resp.json()["supports_reasoning"] is True
+
+
+def test_model_info_unknown_model(authed_client):
+    # Self-hosted / free-text id litellm can't map: no crash, flags false, no price.
+    resp = authed_client.get("/api/settings/model-info?model=totally/unknown-xyz")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["in_registry"] is False
+    assert data["supports_reasoning"] is False
+    assert data["input_price_per_1m"] is None
+
+
+def test_model_info_defaults_to_configured_model(authed_client):
+    # No ?model= -> uses the configured llm_model setting.
+    resp = authed_client.get("/api/settings/model-info")
+    assert resp.status_code == 200
+    assert resp.json()["model"] == "gemini/gemini-3-flash-preview"
+
+
+def test_model_info_requires_auth(app):
+    resp = TestClient(app).get("/api/settings/model-info?model=gpt-4o")
+    assert resp.status_code == 401


### PR DESCRIPTION
**PR2 of issue #13.** Rebased onto `master` after the litellm 1.93 upgrade (#17) merged. Supersedes #18, which GitHub auto-closed when its base branch (`chore/litellm-upgrade`) was deleted on merge — same commits, retargeted to `master`.

The wedge: the `reasoning_effort` control + correct cost accounting + the cheap, high-value slice of the model UI. The full 3k-model searchable combobox is deferred to an optional PR3.

## What's in
**Setting** — `llm_reasoning_effort` (`RECEIPTORY_LLM_REASONING_EFFORT`): `none|minimal|low|medium|high`, default `none`.
- `none` is **byte-identical to today**: no param sent, `supports_reasoning` not even probed.
- `normalize_reasoning_effort()` validates at the use site — DB rows are raw `json.loads`, so any bad value fails safe to `none`. No migration needed (new key; `get_setting` falls back to the default, `init_settings` seeds it on boot).

**All 4 call sites, gated** — `reasoning_effort_kwargs(model, effort)` injects only when `litellm.supports_reasoning(model)`, with `drop_params=True` on the inject path. Wired into `extract.py` and all three `url_triage.py` calls; `pipeline.py` forwards the setting.

**Cost** — `estimate_cost()` uses `litellm.cost_per_token` (proper provider resolution; raises → generic fallback) instead of the hardcoded 3-model table. The model-info endpoint uses `litellm.get_model_info`.

**UI (Settings → LLM Engine)** — `GET /api/settings/model-info` drives a price line + reasoning badge under the model field, and a Reasoning Effort dropdown that disables itself when the model can't reason. Free-text model entry unchanged.

## Review (`/review`, clean)
Claude adversarial + testing specialists. One real bug caught and fixed: the original cost lookup stripped provider prefixes and could resolve to a different-priced registry row (`azure/deepseek-v4-pro` → `deepseek-v4-pro`); now uses litellm's resolvers. +7 tests added (model-info endpoint + cost fallback).

## Acceptance
- [x] `RECEIPTORY_LLM_REASONING_EFFORT=high` reaches every LLM call for a supporting model; `none` → byte-identical.
- [x] Non-reasoning model → control withheld, no `UnsupportedParamsError` in any combination.
- [x] `estimate_cost` correct across model switches (resolver + fallback tested).
- [x] Live: extraction on `gemini/gemini-3-flash-preview` completes at `none` and `high`, records tokens/cost.
- [ ] (PR3, optional) Searchable combobox over the full registry.

## Note
Switching to the registry corrects the default `gemini/gemini-3-flash-preview` price from the old hardcoded `$0.10/$0.40` to the registry's `$0.50/$3.00` per 1M — reported `processing_cost_usd` will read ~6.7× higher (and accurate) going forward.

Full suite: **275 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)