### PR TITLE
fix(settings): pin selected model to top of combobox list (#13)

### DIFF
--- a/frontend/src/components/ModelCombobox.tsx
+++ b/frontend/src/components/ModelCombobox.tsx
@@ -49,7 +49,17 @@ export default function ModelCombobox({
           (m) => m.id.toLowerCase().includes(q) || (m.provider ?? "").toLowerCase().includes(q)
         )
       : models;
-    return { filtered: matches.slice(0, MAX_RESULTS), total: matches.length };
+    // Pin the currently-selected model to the top so it's visible on open even
+    // when it sorts alphabetically past the result cap. Only when it's in the
+    // match set (i.e. not while the user is searching for a different model).
+    let ordered = matches;
+    if (value && matches.some((m) => m.id === value)) {
+      ordered = [
+        ...matches.filter((m) => m.id === value),
+        ...matches.filter((m) => m.id !== value),
+      ];
+    }
+    return { filtered: ordered.slice(0, MAX_RESULTS), total: ordered.length };
   }, [text, value, models]);
 
   const fmtPrice = (m: ModelOption) =>


### PR DESCRIPTION
Follow-up papercut fix from #20's review. The model combobox caps at 50 alphabetical results; a saved model sorting past position 50 wasn't visible on open until the user typed. Now the currently-selected model is pinned to the top of the list whenever it's in the match set (no-op while searching for a different model). Frontend build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)