### PR TITLE
feat(settings): surface env-overridden settings as read-only in UI (#13)

### DIFF
--- a/backend/api/settings.py
+++ b/backend/api/settings.py
@@ -1,7 +1,7 @@
 from fastapi import APIRouter, Depends, HTTPException, Request
 
 from backend.auth import require_auth
-from backend.config import get_all_settings_masked, set_setting, get_setting
+from backend.config import get_all_settings_masked, set_setting, get_setting, env_overridden_keys
 from backend.models import SettingsUpdate
 
 router = APIRouter()
@@ -10,6 +10,13 @@ router = APIRouter()
 @router.get("/settings")
 def get_settings(username: str = Depends(require_auth)):
     return get_all_settings_masked()
+
+
+@router.get("/settings/env-overrides")
+def settings_env_overrides(username: str = Depends(require_auth)):
+    """Keys currently pinned by an env var (env > db precedence). The UI shows
+    these fields as read-only so edits aren't silently discarded (#13)."""
+    return {"keys": env_overridden_keys()}
 
 
 @router.patch("/settings")

--- a/backend/config.py
+++ b/backend/config.py
@@ -121,6 +121,22 @@ def get_all_settings() -> dict[str, Any]:
     return {key: get_setting(key) for key in DEFAULTS}
 
 
+def env_overridden_keys() -> list[str]:
+    """Settings whose value is currently pinned by an environment variable.
+
+    Config precedence is env > db > default, so for these keys a UI edit writes
+    the DB but is never read back — get_setting always returns the env value.
+    The UI uses this to show such fields as read-only ("managed by .env") instead
+    of silently discarding edits. Mirrors get_setting's env check exactly
+    (present and non-empty)."""
+    out = []
+    for key in DEFAULTS:
+        val = os.environ.get(f"RECEIPTORY_{key.upper()}")
+        if val is not None and val != "":
+            out.append(key)
+    return out
+
+
 def get_all_settings_masked() -> dict[str, Any]:
     settings = get_all_settings()
     for key in SENSITIVE_KEYS:

--- a/frontend/src/components/ModelCombobox.tsx
+++ b/frontend/src/components/ModelCombobox.tsx
@@ -25,12 +25,14 @@ export default function ModelCombobox({
   onCommit,
   className,
   placeholder,
+  disabled,
 }: {
   value: string;
   models: ModelOption[];
   onCommit: (id: string) => void;
   className?: string;
   placeholder?: string;
+  disabled?: boolean;
 }) {
   const [text, setText] = useState(value ?? "");
   // Keep local input text in sync when the saved value changes elsewhere.
@@ -82,6 +84,7 @@ export default function ModelCombobox({
       <Autocomplete.Input
         placeholder={placeholder ?? "gpt-4o"}
         className={className}
+        disabled={disabled}
         onBlur={() => commit(text)}
       />
       <Autocomplete.Portal>

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -96,12 +96,22 @@ export default function SettingsPage() {
   const [notifyTestResult, setNotifyTestResult] = useState<string | null>(null);
   const [modelInfo, setModelInfo] = useState<any>(null);
   const [models, setModels] = useState<ModelOption[]>([]);
+  const [envKeys, setEnvKeys] = useState<string[]>([]);
 
   // Load the vision-capable chat model registry once for the picker (#13, PR3).
   // Cached server-side; failure just leaves the combobox as a free-text field.
   useEffect(() => {
     api.get("/settings/llm-models").then((r: any) => setModels(r.models || [])).catch(() => setModels([]));
+    // Which settings are pinned by an env var (env > db). Edits to these are
+    // silently discarded, so the UI shows them read-only instead (#13).
+    api.get("/settings/env-overrides").then((r: any) => setEnvKeys(r.keys || [])).catch(() => setEnvKeys([]));
   }, []);
+
+  const envLocked = (k: string) => envKeys.includes(k);
+  const envHint = (k: string, base?: string) =>
+    envLocked(k)
+      ? `Managed by RECEIPTORY_${k.toUpperCase()} in .env — edit the environment to change (UI edits are ignored while set).`
+      : base;
 
   // Look up price + reasoning support for the current model (issue #13).
   // Debounced so typing into the free-text model field doesn't fire a request
@@ -304,11 +314,12 @@ export default function SettingsPage() {
             <SectionCard title="LLM Intelligence Engine" icon="psychology" badge="Active">
               <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
                 <div className="space-y-4">
-                  <FieldGroup label="Extraction Model">
+                  <FieldGroup label="Extraction Model" hint={envHint("llm_model")}>
                     <ModelCombobox
                       value={settings.llm_model || ""}
                       models={models}
-                      className={`${inputCls} w-full px-3`}
+                      disabled={envLocked("llm_model")}
+                      className={`${inputCls} w-full px-3 disabled:opacity-50 disabled:cursor-not-allowed`}
                       onCommit={(id) => { setSettings({ ...settings, llm_model: id }); save({ llm_model: id }); }}
                     />
                     {modelInfo && modelInfo.model === settings.llm_model && (
@@ -328,27 +339,28 @@ export default function SettingsPage() {
                       </div>
                     )}
                   </FieldGroup>
-                  <FieldGroup label="API Key">
-                    <Input className={inputCls} type="password" value={settings.llm_api_key || ""} onBlur={(e) => { if (e.target.value && !e.target.value.includes("***")) save({ llm_api_key: e.target.value }); }} onChange={(e) => setSettings({ ...settings, llm_api_key: e.target.value })} />
+                  <FieldGroup label="API Key" hint={envHint("llm_api_key")}>
+                    <Input className={inputCls} type="password" disabled={envLocked("llm_api_key")} value={settings.llm_api_key || ""} onBlur={(e) => { if (e.target.value && !e.target.value.includes("***")) save({ llm_api_key: e.target.value }); }} onChange={(e) => setSettings({ ...settings, llm_api_key: e.target.value })} />
                   </FieldGroup>
-                  <FieldGroup label="Temperature" hint="Gemini 3 is tuned for 1.0. Lower values can degrade extraction quality.">
-                    <Input className={inputCls} type="number" step="0.1" min="0" max="2" value={settings.llm_temperature ?? 1} onBlur={(e) => save({ llm_temperature: parseFloat(e.target.value) })} onChange={(e) => setSettings({ ...settings, llm_temperature: e.target.value })} />
+                  <FieldGroup label="Temperature" hint={envHint("llm_temperature", "Gemini 3 is tuned for 1.0. Lower values can degrade extraction quality.")}>
+                    <Input className={inputCls} type="number" step="0.1" min="0" max="2" disabled={envLocked("llm_temperature")} value={settings.llm_temperature ?? 1} onBlur={(e) => save({ llm_temperature: parseFloat(e.target.value) })} onChange={(e) => setSettings({ ...settings, llm_temperature: e.target.value })} />
                   </FieldGroup>
-                  <FieldGroup label="Max Output Tokens">
-                    <Input className={inputCls} type="number" step="1024" min="1024" max="32768" value={settings.llm_max_tokens ?? 8192} onBlur={(e) => save({ llm_max_tokens: parseInt(e.target.value) || 8192 })} onChange={(e) => setSettings({ ...settings, llm_max_tokens: e.target.value })} />
+                  <FieldGroup label="Max Output Tokens" hint={envHint("llm_max_tokens")}>
+                    <Input className={inputCls} type="number" step="1024" min="1024" max="32768" disabled={envLocked("llm_max_tokens")} value={settings.llm_max_tokens ?? 8192} onBlur={(e) => save({ llm_max_tokens: parseInt(e.target.value) || 8192 })} onChange={(e) => setSettings({ ...settings, llm_max_tokens: e.target.value })} />
                   </FieldGroup>
                   <FieldGroup
                     label="Reasoning Effort"
                     hint={
-                      modelInfo && modelInfo.model === settings.llm_model && !modelInfo.supports_reasoning
-                        ? "The selected model does not support reasoning. Effort is ignored."
-                        : "Higher effort spends more reasoning (output) tokens per document, raising cost. \"None\" sends no reasoning parameter."
+                      envHint("llm_reasoning_effort",
+                        modelInfo && modelInfo.model === settings.llm_model && !modelInfo.supports_reasoning
+                          ? "The selected model does not support reasoning. Effort is ignored."
+                          : "Higher effort spends more reasoning (output) tokens per document, raising cost. \"None\" sends no reasoning parameter.")
                     }
                   >
                     <select
                       className={`${inputCls} w-full px-3 disabled:opacity-50 disabled:cursor-not-allowed`}
                       value={typeof settings.llm_reasoning_effort === "string" ? settings.llm_reasoning_effort : "none"}
-                      disabled={!!(modelInfo && modelInfo.model === settings.llm_model && !modelInfo.supports_reasoning)}
+                      disabled={envLocked("llm_reasoning_effort") || !!(modelInfo && modelInfo.model === settings.llm_model && !modelInfo.supports_reasoning)}
                       onChange={(e) => { setSettings({ ...settings, llm_reasoning_effort: e.target.value }); save({ llm_reasoning_effort: e.target.value }); }}
                     >
                       <option value="none">None (default)</option>
@@ -358,12 +370,12 @@ export default function SettingsPage() {
                       <option value="high">High</option>
                     </select>
                   </FieldGroup>
-                  <FieldGroup label="Sleep Between Calls (seconds)">
-                    <Input className={inputCls} type="number" step="0.1" value={settings.llm_sleep_interval ?? ""} onBlur={(e) => save({ llm_sleep_interval: parseFloat(e.target.value) })} onChange={(e) => setSettings({ ...settings, llm_sleep_interval: e.target.value })} />
+                  <FieldGroup label="Sleep Between Calls (seconds)" hint={envHint("llm_sleep_interval")}>
+                    <Input className={inputCls} type="number" step="0.1" disabled={envLocked("llm_sleep_interval")} value={settings.llm_sleep_interval ?? ""} onBlur={(e) => save({ llm_sleep_interval: parseFloat(e.target.value) })} onChange={(e) => setSettings({ ...settings, llm_sleep_interval: e.target.value })} />
                   </FieldGroup>
                 </div>
                 <div className="space-y-4">
-                  <FieldGroup label="Confidence Threshold">
+                  <FieldGroup label="Confidence Threshold" hint={envHint("confidence_threshold")}>
                     <div className="flex items-center justify-between mb-1">
                       <span className="text-xs text-muted-foreground">Documents below this are flagged for review</span>
                       <span className="text-xs font-mono bg-muted px-2 py-0.5 rounded">{Math.round((settings.confidence_threshold ?? 0.8) * 100)}%</span>
@@ -371,8 +383,9 @@ export default function SettingsPage() {
                     <input
                       type="range"
                       min="0" max="1" step="0.05"
+                      disabled={envLocked("confidence_threshold")}
                       value={settings.confidence_threshold ?? 0.8}
-                      className="w-full h-1.5 bg-accent rounded-lg appearance-none cursor-pointer accent-primary"
+                      className="w-full h-1.5 bg-accent rounded-lg appearance-none cursor-pointer accent-primary disabled:opacity-50 disabled:cursor-not-allowed"
                       onChange={(e) => setSettings({ ...settings, confidence_threshold: parseFloat(e.target.value) })}
                       onMouseUp={(e) => save({ confidence_threshold: parseFloat((e.target as HTMLInputElement).value) })}
                     />

--- a/tests/test_settings_api.py
+++ b/tests/test_settings_api.py
@@ -102,3 +102,23 @@ def test_llm_models_lists_vision_chat_models(authed_client):
 def test_llm_models_requires_auth(app):
     resp = TestClient(app).get("/api/settings/llm-models")
     assert resp.status_code == 401
+
+
+def test_env_overrides_reports_pinned_keys(authed_client, monkeypatch):
+    # A setting pinned by an env var must be reported so the UI can lock it (#13).
+    monkeypatch.setenv("RECEIPTORY_LLM_MODEL", "gpt-4o")
+    resp = authed_client.get("/api/settings/env-overrides")
+    assert resp.status_code == 200
+    assert "llm_model" in resp.json()["keys"]
+
+
+def test_env_overrides_empty_without_env(authed_client):
+    # No RECEIPTORY_* env set (conftest clears them) -> nothing locked.
+    resp = authed_client.get("/api/settings/env-overrides")
+    assert resp.status_code == 200
+    assert resp.json()["keys"] == []
+
+
+def test_env_overrides_requires_auth(app):
+    resp = TestClient(app).get("/api/settings/env-overrides")
+    assert resp.status_code == 401


### PR DESCRIPTION
## Root cause
"Changed the extraction model in the UI but it reverts and the system keeps using the old one." Config precedence is **env > db > default**, and litellm loads `.env` on import. Any setting also pinned by a `RECEIPTORY_*` env var is read back from the env — so the combobox (and every other control) writes the DB but the value is never used. Proven: DB holds `gpt-4o` after save, `get_setting` returns the `.env` value.

This affects ~19 settings pinned in a typical `.env` (model, temperature, max tokens, confidence, business info, gmail, ...) — all editable, all silently discarded, with no indication.

## Fix (make the UI honest — precedence unchanged)
- **Backend:** `GET /api/settings/env-overrides` → keys currently pinned by an env var (`config.env_overridden_keys()`, mirrors `get_setting`'s env check).
- **Frontend:** LLM Engine fields (model, API key, temperature, max tokens, reasoning effort, sleep, confidence) render **disabled with a "Managed by RECEIPTORY_X in .env" hint** when env-pinned, instead of accepting edits that get thrown away.

Does **not** change precedence — env stays authoritative by design. To make a setting UI-controlled, remove its line from `.env`.

## Tests
env-overrides endpoint: reports the pinned key, empty when none set, auth-401. Full suite: **280 passed**. Frontend builds clean.

## Follow-up (separate, needs owner confirmation)
To actually control the model from the UI you must unpin `RECEIPTORY_LLM_MODEL` in `.env`. Heads-up: the live DB already holds a stale `llm_model` (`gemini/gemini-3.5-flash`) from earlier UI clicks and `llm_max_tokens=8192` vs env's `16384`, so unpinning needs the DB reset to the intended effective values first to avoid a silent behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)