### PR TITLE
feat(llm): named provider API keys with UI picker (#13)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,7 +15,13 @@
 # RECEIPTORY_REFERENCE_CURRENCY=ILS
 
 # --- LLM (required) ---
-# RECEIPTORY_LLM_API_KEY=your-api-key-here
+# RECEIPTORY_LLM_API_KEY=your-api-key-here   # legacy single key; fallback when no named key is picked
+# Named provider keys: define one per provider and pick the matching one in
+# Settings -> LLM Engine -> Provider Key. The suffix after RECEIPTORY_LLM_API_KEY_
+# is the label shown in the picker.
+# RECEIPTORY_LLM_API_KEY_GEMINI=...
+# RECEIPTORY_LLM_API_KEY_OPENAI=...
+# RECEIPTORY_LLM_API_KEY_TOGETHERAI=...
 # RECEIPTORY_LLM_MODEL=gemini/gemini-3-flash-preview
 # RECEIPTORY_LLM_TEMPERATURE=1.0        # Gemini 3 is tuned for temperature 1.0; lower values can degrade quality
 # RECEIPTORY_LLM_MAX_TOKENS=16384       # increase if JSON gets truncated

--- a/backend/api/settings.py
+++ b/backend/api/settings.py
@@ -1,7 +1,7 @@
 from fastapi import APIRouter, Depends, HTTPException, Request
 
 from backend.auth import require_auth
-from backend.config import get_all_settings_masked, set_setting, get_setting, env_overridden_keys
+from backend.config import get_all_settings_masked, set_setting, get_setting, env_overridden_keys, list_named_api_keys, resolve_llm_api_key
 from backend.models import SettingsUpdate
 
 router = APIRouter()
@@ -10,6 +10,31 @@ router = APIRouter()
 @router.get("/settings")
 def get_settings(username: str = Depends(require_auth)):
     return get_all_settings_masked()
+
+
+@router.get("/settings/llm-api-keys")
+def llm_api_keys(username: str = Depends(require_auth)):
+    """Named provider API keys available for the picker (#13). Returns the LABELS
+    of RECEIPTORY_LLM_API_KEY_<LABEL> env vars (never the secret values), which
+    one is selected, and the provider of the currently selected model so the
+    user can pick the matching key."""
+    import litellm
+
+    model = get_setting("llm_model")
+    provider = None
+    if model:
+        try:
+            provider = litellm.get_llm_provider(model=model)[1]
+        except Exception:
+            provider = None
+    ref = get_setting("llm_api_key_ref")
+    return {
+        "keys": list_named_api_keys(),
+        "selected": ref if isinstance(ref, str) else "",
+        "legacy_key_set": bool(get_setting("llm_api_key")),
+        "model": model,
+        "model_provider": provider,
+    }
 
 
 @router.get("/settings/env-overrides")
@@ -38,7 +63,7 @@ def test_llm(username: str = Depends(require_auth)):
     import litellm
 
     model = get_setting("llm_model")
-    api_key = get_setting("llm_api_key")
+    api_key = resolve_llm_api_key()
     if not api_key:
         raise HTTPException(status_code=400, detail="No API key configured")
 

--- a/backend/config.py
+++ b/backend/config.py
@@ -1,5 +1,6 @@
 import json
 import os
+import re
 import logging
 from typing import Any
 
@@ -15,6 +16,7 @@ DEFAULTS: dict[str, Any] = {
     "reference_currency": "ILS",
     "llm_model": "gemini/gemini-3-flash-preview",
     "llm_api_key": "",
+    "llm_api_key_ref": "",
     "llm_temperature": 1.0,
     "llm_max_tokens": 8192,
     "llm_json_mode": True,
@@ -83,6 +85,42 @@ SENSITIVE_KEYS = {
     "gdrive_client_secret", "onedrive_client_secret",
     "cloud_auth_gdrive_token", "cloud_auth_onedrive_token", "cloud_auth_state",
 }
+
+
+# Named provider API keys: RECEIPTORY_LLM_API_KEY_<LABEL> (e.g. _GEMINI, _OPENAI,
+# _TOGETHERAI). The suffix labels which provider a key is for; the user picks one
+# (llm_api_key_ref) to match the selected model. Distinct from the legacy
+# single-key RECEIPTORY_LLM_API_KEY (no suffix), which stays the fallback.
+_NAMED_API_KEY_RE = re.compile(r"^RECEIPTORY_LLM_API_KEY_(.+)$")
+
+
+def list_named_api_keys() -> list[str]:
+    """Labels of non-empty RECEIPTORY_LLM_API_KEY_<LABEL> env vars (values never
+    exposed). Drives the API-key picker."""
+    out = []
+    for k, v in os.environ.items():
+        m = _NAMED_API_KEY_RE.match(k)
+        if m and v:
+            out.append(m.group(1))
+    return sorted(out)
+
+
+def resolve_llm_api_key() -> str:
+    """The API key to send to litellm. If a named key is selected
+    (llm_api_key_ref) and present in the environment, use it; otherwise fall
+    back to the legacy single llm_api_key (env > db)."""
+    # The ref lookup is best-effort: if the DB isn't available (e.g. an early
+    # env-only code path), fall straight through to the legacy key rather than
+    # letting a RuntimeError escape — the legacy read preserves prior behavior.
+    try:
+        ref = get_setting("llm_api_key_ref")
+    except Exception:
+        ref = ""
+    if isinstance(ref, str) and ref:
+        v = os.environ.get(f"RECEIPTORY_LLM_API_KEY_{ref}")
+        if v:
+            return v
+    return get_setting("llm_api_key") or ""
 
 
 def get_setting(key: str) -> Any:

--- a/backend/ingestion/url_triage.py
+++ b/backend/ingestion/url_triage.py
@@ -6,7 +6,7 @@ import logging
 import re
 from dataclasses import dataclass
 
-from backend.config import get_setting
+from backend.config import get_setting, resolve_llm_api_key
 from backend.processing.extract import litellm_completion, reasoning_effort_kwargs
 
 logger = logging.getLogger(__name__)
@@ -36,7 +36,7 @@ async def triage_telegram_urls(message_text: str, urls: list[str]) -> list[str]:
         return []
 
     model = get_setting("llm_model")
-    api_key = get_setting("llm_api_key")
+    api_key = resolve_llm_api_key()
     temperature = get_setting("llm_temperature")
     reasoning_effort = get_setting("llm_reasoning_effort")
 
@@ -99,7 +99,7 @@ async def triage_email_urls(
 
     try:
         model = get_setting("llm_model")
-        api_key = get_setting("llm_api_key")
+        api_key = resolve_llm_api_key()
         temperature = get_setting("llm_temperature")
         reasoning_effort = get_setting("llm_reasoning_effort")
     except RuntimeError:
@@ -175,7 +175,7 @@ async def classify_email_documents(
 
     try:
         model = get_setting("llm_model")
-        api_key = get_setting("llm_api_key")
+        api_key = resolve_llm_api_key()
         temperature = get_setting("llm_temperature")
         reasoning_effort = get_setting("llm_reasoning_effort")
     except RuntimeError:

--- a/backend/processing/pipeline.py
+++ b/backend/processing/pipeline.py
@@ -4,7 +4,7 @@ import logging
 from datetime import datetime, timezone
 
 from backend.database import get_connection
-from backend.config import get_setting
+from backend.config import get_setting, resolve_llm_api_key
 from backend.storage import (get_file_path, save_filed, render_all_pages_to_memory, get_pdf_page_count)
 from backend.processing.normalize import normalize_file
 from backend.processing.extract import extract_document, ExtractionResult
@@ -54,7 +54,7 @@ def _run_pipeline(doc_id: int, doc: dict, data_dir: str) -> None:
     dpi = get_setting("page_render_dpi")
     page_images = render_all_pages_to_memory(pdf_path, dpi=dpi)
     model = get_setting("llm_model")
-    api_key = get_setting("llm_api_key")
+    api_key = resolve_llm_api_key()
     business_names = get_setting("business_names")
     business_addresses = get_setting("business_addresses")
     business_tax_ids = get_setting("business_tax_ids")

--- a/backend/processing/queue.py
+++ b/backend/processing/queue.py
@@ -2,7 +2,7 @@ import asyncio
 import logging
 
 from backend.database import get_connection
-from backend.config import get_setting
+from backend.config import get_setting, resolve_llm_api_key
 from backend.processing.pipeline import process_document
 
 logger = logging.getLogger(__name__)
@@ -47,7 +47,7 @@ async def run_queue_loop(data_dir: str) -> None:
             if doc is None:
                 await asyncio.sleep(2.0)
                 continue
-            api_key = get_setting("llm_api_key")
+            api_key = resolve_llm_api_key()
             if not api_key:
                 logger.warning("No LLM API key configured, skipping processing")
                 await asyncio.sleep(10.0)

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -97,6 +97,7 @@ export default function SettingsPage() {
   const [modelInfo, setModelInfo] = useState<any>(null);
   const [models, setModels] = useState<ModelOption[]>([]);
   const [envKeys, setEnvKeys] = useState<string[]>([]);
+  const [apiKeyLabels, setApiKeyLabels] = useState<string[]>([]);
 
   // Load the vision-capable chat model registry once for the picker (#13, PR3).
   // Cached server-side; failure just leaves the combobox as a free-text field.
@@ -105,6 +106,8 @@ export default function SettingsPage() {
     // Which settings are pinned by an env var (env > db). Edits to these are
     // silently discarded, so the UI shows them read-only instead (#13).
     api.get("/settings/env-overrides").then((r: any) => setEnvKeys(r.keys || [])).catch(() => setEnvKeys([]));
+    // Named provider API keys from .env (RECEIPTORY_LLM_API_KEY_<LABEL>) for the picker (#13).
+    api.get("/settings/llm-api-keys").then((r: any) => setApiKeyLabels(r.keys || [])).catch(() => setApiKeyLabels([]));
   }, []);
 
   const envLocked = (k: string) => envKeys.includes(k);
@@ -345,8 +348,38 @@ export default function SettingsPage() {
                       </div>
                     )}
                   </FieldGroup>
-                  <FieldGroup label="API Key" hint={envHint("llm_api_key")}>
-                    <Input className={inputCls} type="password" disabled={envLocked("llm_api_key")} value={settings.llm_api_key || ""} onBlur={(e) => { if (e.target.value && !e.target.value.includes("***")) save({ llm_api_key: e.target.value }); }} onChange={(e) => setSettings({ ...settings, llm_api_key: e.target.value })} />
+                  {(apiKeyLabels.length > 0 || (typeof settings.llm_api_key_ref === "string" && settings.llm_api_key_ref)) && (
+                    <FieldGroup
+                      label="Provider Key (from .env)"
+                      hint={
+                        `Named keys defined as RECEIPTORY_LLM_API_KEY_<LABEL> in .env.` +
+                        (modelInfo && modelInfo.model === settings.llm_model && modelInfo.provider
+                          ? ` Selected model provider: ${modelInfo.provider} — pick the matching key.`
+                          : "")
+                      }
+                    >
+                      <select
+                        className={`${inputCls} w-full px-3`}
+                        value={typeof settings.llm_api_key_ref === "string" ? settings.llm_api_key_ref : ""}
+                        onChange={(e) => { setSettings({ ...settings, llm_api_key_ref: e.target.value }); save({ llm_api_key_ref: e.target.value }); }}
+                      >
+                        <option value="">Use single key below</option>
+                        {apiKeyLabels.map((k) => <option key={k} value={k}>{k}</option>)}
+                        {typeof settings.llm_api_key_ref === "string" && settings.llm_api_key_ref && !apiKeyLabels.includes(settings.llm_api_key_ref) && (
+                          <option value={settings.llm_api_key_ref}>{settings.llm_api_key_ref} (not found in .env)</option>
+                        )}
+                      </select>
+                    </FieldGroup>
+                  )}
+                  <FieldGroup
+                    label="API Key"
+                    hint={
+                      (typeof settings.llm_api_key_ref === "string" && settings.llm_api_key_ref)
+                        ? `Overridden by the selected provider key "${settings.llm_api_key_ref}". Set the picker to "Use single key below" to use this field.`
+                        : envHint("llm_api_key")
+                    }
+                  >
+                    <Input className={inputCls} type="password" disabled={envLocked("llm_api_key") || !!(typeof settings.llm_api_key_ref === "string" && settings.llm_api_key_ref)} value={settings.llm_api_key || ""} onBlur={(e) => { if (e.target.value && !e.target.value.includes("***")) save({ llm_api_key: e.target.value }); }} onChange={(e) => setSettings({ ...settings, llm_api_key: e.target.value })} />
                   </FieldGroup>
                   <FieldGroup label="Temperature" hint={envHint("llm_temperature", "Gemini 3 is tuned for 1.0. Lower values can degrade extraction quality.")}>
                     <Input className={inputCls} type="number" step="0.1" min="0" max="2" disabled={envLocked("llm_temperature")} value={settings.llm_temperature ?? 1} onBlur={(e) => save({ llm_temperature: parseFloat(e.target.value) })} onChange={(e) => setSettings({ ...settings, llm_temperature: e.target.value })} />

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -64,3 +64,36 @@ def test_init_settings_seeds_defaults(db_path):
     with get_connection() as conn:
         row = conn.execute("SELECT value FROM settings WHERE key = 'llm_model'").fetchone()
         assert row is not None
+
+
+# --- Named provider API keys (#13) ---
+
+def test_list_named_api_keys_filters_empty_and_legacy(db_path, monkeypatch):
+    from backend.config import list_named_api_keys
+    monkeypatch.setenv("RECEIPTORY_LLM_API_KEY_GEMINI", "gk")
+    monkeypatch.setenv("RECEIPTORY_LLM_API_KEY_OPENAI", "sk")
+    monkeypatch.setenv("RECEIPTORY_LLM_API_KEY_EMPTY", "")   # empty -> excluded
+    monkeypatch.setenv("RECEIPTORY_LLM_API_KEY", "legacy")   # no suffix -> excluded
+    assert list_named_api_keys() == ["GEMINI", "OPENAI"]
+
+
+def test_resolve_llm_api_key_uses_selected_named_key(db_path, monkeypatch):
+    from backend.config import resolve_llm_api_key
+    monkeypatch.setenv("RECEIPTORY_LLM_API_KEY_OPENAI", "sk-openai")
+    set_setting("llm_api_key_ref", "OPENAI")
+    set_setting("llm_api_key", "legacy-gemini")
+    assert resolve_llm_api_key() == "sk-openai"
+
+
+def test_resolve_llm_api_key_falls_back_to_legacy_when_ref_missing(db_path, monkeypatch):
+    from backend.config import resolve_llm_api_key
+    # ref points at a label with no env var present -> legacy key.
+    set_setting("llm_api_key_ref", "GHOST")
+    set_setting("llm_api_key", "legacy-key")
+    assert resolve_llm_api_key() == "legacy-key"
+
+
+def test_resolve_llm_api_key_no_ref_uses_legacy(db_path):
+    from backend.config import resolve_llm_api_key
+    set_setting("llm_api_key", "legacy-key")
+    assert resolve_llm_api_key() == "legacy-key"

--- a/tests/test_settings_api.py
+++ b/tests/test_settings_api.py
@@ -131,3 +131,22 @@ def test_env_overrides_empty_without_env(authed_client):
 def test_env_overrides_requires_auth(app):
     resp = TestClient(app).get("/api/settings/env-overrides")
     assert resp.status_code == 401
+
+
+def test_llm_api_keys_lists_labels_and_provider(authed_client, monkeypatch):
+    # PR: named provider keys picker (#13). Labels only, never values.
+    monkeypatch.setenv("RECEIPTORY_LLM_API_KEY_GEMINI", "gk")
+    monkeypatch.setenv("RECEIPTORY_LLM_API_KEY_OPENAI", "sk")
+    resp = authed_client.get("/api/settings/llm-api-keys")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["keys"] == ["GEMINI", "OPENAI"]
+    # default model is gemini/* -> provider resolves to gemini
+    assert data["model_provider"] == "gemini"
+    # secret values are never returned
+    assert "gk" not in resp.text and "sk" not in resp.text
+
+
+def test_llm_api_keys_requires_auth(app):
+    resp = TestClient(app).get("/api/settings/llm-api-keys")
+    assert resp.status_code == 401

--- a/tests/test_url_triage.py
+++ b/tests/test_url_triage.py
@@ -65,6 +65,7 @@ class TestTriageTelegramUrls:
         )
 
         with patch("backend.ingestion.url_triage.litellm_completion", return_value=llm_response) as mock_llm, \
+             patch("backend.ingestion.url_triage.resolve_llm_api_key", return_value="test-key"), \
              patch("backend.ingestion.url_triage.get_setting", side_effect=_stub_settings):
             result = await triage_telegram_urls("Here's my receipt", urls)
 
@@ -134,6 +135,7 @@ class TestTemperatureFlowsToLLM:
     async def test_telegram_passes_temperature(self, db_path):
         llm_response = _make_llm_response(json.dumps([]))
         with patch("backend.ingestion.url_triage.litellm_completion", return_value=llm_response) as mock_llm, \
+             patch("backend.ingestion.url_triage.resolve_llm_api_key", return_value="test-key"), \
              patch("backend.ingestion.url_triage.get_setting", side_effect=_stub_settings):
             await triage_telegram_urls("text", ["https://a.com"])
         assert mock_llm.call_args.kwargs["temperature"] == 0.5
@@ -142,6 +144,7 @@ class TestTemperatureFlowsToLLM:
     async def test_email_urls_passes_temperature(self, db_path):
         llm_response = _make_llm_response(json.dumps([]))
         with patch("backend.ingestion.url_triage.litellm_completion", return_value=llm_response) as mock_llm, \
+             patch("backend.ingestion.url_triage.resolve_llm_api_key", return_value="test-key"), \
              patch("backend.ingestion.url_triage.get_setting", side_effect=_stub_settings):
             await triage_email_urls("s@x.com", "subject", "body", ["https://a.com"])
         assert mock_llm.call_args.kwargs["temperature"] == 0.5
@@ -151,6 +154,7 @@ class TestTemperatureFlowsToLLM:
         llm_response = _make_llm_response(json.dumps([]))
         docs = [ClassificationDocument(identifier="a.pdf", source="attachment", first_page_image=_PNG_1PX)]
         with patch("backend.ingestion.url_triage.litellm_completion", return_value=llm_response) as mock_llm, \
+             patch("backend.ingestion.url_triage.resolve_llm_api_key", return_value="test-key"), \
              patch("backend.ingestion.url_triage.get_setting", side_effect=_stub_settings):
             await classify_email_documents("s@x.com", "subject", "body", docs)
         assert mock_llm.call_args.kwargs["temperature"] == 0.5


### PR DESCRIPTION
Lets you keep several provider keys in `.env` and pick which one to use per model — so switching LLM providers in the UI can also switch the API key.

## How it works
Define keys under a suffix convention:
```
RECEIPTORY_LLM_API_KEY_GEMINI=...
RECEIPTORY_LLM_API_KEY_OPENAI=...
RECEIPTORY_LLM_API_KEY_TOGETHERAI=...
```
Settings → LLM Engine shows a **Provider Key** dropdown of those labels, with the **selected model's provider** as a hint (via `litellm.get_llm_provider`) so you pick the matching one. Pick a label → it's used for all LLM calls; the legacy single-key field is disabled while a label is selected. Leave it on "Use single key below" to fall back to the legacy `RECEIPTORY_LLM_API_KEY` / UI key.

## Backend
- `config.list_named_api_keys()` — enumerates the **labels only** (regex `^RECEIPTORY_LLM_API_KEY_(.+)$`; can't match the legacy no-suffix key). Values never leave the process.
- `config.resolve_llm_api_key()` — selected named key (if present in env) → else legacy key. All 6 api_key read sites (pipeline, queue, url_triage ×3, test-llm) route through it.
- `GET /settings/llm-api-keys` — labels + selected + `legacy_key_set` + model provider. Never returns key values (test asserts this).

## Review (adversarial, clean → ship)
Secret-safety verified: no endpoint returns a key value, the label regex can't leak the legacy key, `llm_api_key_ref` is a non-secret label. Resolve precedence + fallback + non-string-ref guard all correct and tested. Fixed one finding: a stale `llm_api_key_ref` with no named env keys made the whole picker vanish, leaving the disabled legacy field un-clearable — now the dropdown (and its "Use single key below" recovery) always renders when a ref is set.

## Known non-issue
Picking a key whose provider doesn't match the model (e.g. GEMINI key + gpt-4o) fails at request time (surfaced by "Test LLM Connection"); the provider hint nudges the right pick. Acceptable user-error for a single-user tool.

Tests +8. Full suite: **287 passed**. Frontend builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)