### PR TITLE
feat(settings): DB-managed LLM API keys (named list, UI-editable) (#25)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,13 +15,11 @@
 # RECEIPTORY_REFERENCE_CURRENCY=ILS
 
 # --- LLM (required) ---
-# RECEIPTORY_LLM_API_KEY=your-api-key-here   # legacy single key; fallback when no named key is picked
-# Named provider keys: define one per provider and pick the matching one in
-# Settings -> LLM Engine -> Provider Key. The suffix after RECEIPTORY_LLM_API_KEY_
-# is the label shown in the picker.
-# RECEIPTORY_LLM_API_KEY_GEMINI=...
-# RECEIPTORY_LLM_API_KEY_OPENAI=...
-# RECEIPTORY_LLM_API_KEY_TOGETHERAI=...
+# Provider API keys are managed in the UI: Settings -> LLM Engine -> API Keys
+# (stored in the database, one named entry per key). This single env key is
+# imported into that list once at first startup, then used only as a fallback
+# when no key is selected in the UI. No per-provider env vars are needed.
+# RECEIPTORY_LLM_API_KEY=your-api-key-here
 # RECEIPTORY_LLM_MODEL=gemini/gemini-3-flash-preview
 # RECEIPTORY_LLM_TEMPERATURE=1.0        # Gemini 3 is tuned for temperature 1.0; lower values can degrade quality
 # RECEIPTORY_LLM_MAX_TOKENS=16384       # increase if JSON gets truncated

--- a/backend/api/settings.py
+++ b/backend/api/settings.py
@@ -1,8 +1,13 @@
+import os
+
 from fastapi import APIRouter, Depends, HTTPException, Request
 
 from backend.auth import require_auth
-from backend.config import get_all_settings_masked, set_setting, get_setting, env_overridden_keys, list_named_api_keys, resolve_llm_api_key
-from backend.models import SettingsUpdate
+from backend.config import (
+    get_all_settings_masked, set_setting, get_setting, env_overridden_keys,
+    resolve_llm_api_key, list_llm_api_keys, mutate_llm_api_keys, provider_of,
+)
+from backend.models import SettingsUpdate, ApiKeyCreate, SelectedKeyUpdate
 
 router = APIRouter()
 
@@ -12,29 +17,85 @@ def get_settings(username: str = Depends(require_auth)):
     return get_all_settings_masked()
 
 
+def _api_keys_payload():
+    """Shared response for the key-manager: masked key list, selection, model
+    provider, and whether the legacy env fallback is present. Never returns key
+    material — only name + last4 (issue #25)."""
+    model = get_setting("llm_model")
+    ref = get_setting("llm_api_key_ref")
+    keys = [
+        {"name": e.get("name", ""), "last4": (e.get("key") or "")[-4:]}
+        for e in list_llm_api_keys()
+        if isinstance(e, dict)
+    ]
+    return {
+        "keys": keys,
+        "selected": ref if isinstance(ref, str) else "",
+        "legacy_env_key_set": bool(os.environ.get("RECEIPTORY_LLM_API_KEY")),
+        "model": model,
+        "model_provider": provider_of(model),
+    }
+
+
 @router.get("/settings/llm-api-keys")
 def llm_api_keys(username: str = Depends(require_auth)):
-    """Named provider API keys available for the picker (#13). Returns the LABELS
-    of RECEIPTORY_LLM_API_KEY_<LABEL> env vars (never the secret values), which
-    one is selected, and the provider of the currently selected model so the
-    user can pick the matching key."""
-    import litellm
+    """The DB-managed LLM API keys for the Settings key manager (issue #25).
+    Returns each key's name + last-4 (never the full secret), which one is
+    selected, the model, and its provider so the user can pick a matching key."""
+    return _api_keys_payload()
 
-    model = get_setting("llm_model")
-    provider = None
-    if model:
-        try:
-            provider = litellm.get_llm_provider(model=model)[1]
-        except Exception:
-            provider = None
+
+@router.post("/settings/llm-api-keys")
+def add_llm_api_key(body: ApiKeyCreate, username: str = Depends(require_auth)):
+    """Add or replace a named key. Case-insensitive name match, so 'OpenAI'
+    updates 'openai' instead of duplicating it (the newest casing wins)."""
+    name = body.name.strip()
+    key = body.key.strip()
+    if not name:
+        raise HTTPException(status_code=400, detail="Key name is required")
+    if not key:
+        raise HTTPException(status_code=400, detail="Key value is required")
+    if "/" in name:
+        # The name is the DELETE path segment; a slash would make the entry
+        # unreachable by that route (undeletable from the UI).
+        raise HTTPException(status_code=400, detail="Key name cannot contain '/'")
+
+    def _apply(entries):
+        kept = [e for e in entries if isinstance(e, dict)
+                and e.get("name", "").lower() != name.lower()]
+        kept.append({"name": name, "key": key})
+        return kept
+
+    mutate_llm_api_keys(_apply)
+    return _api_keys_payload()
+
+
+@router.delete("/settings/llm-api-keys/{name}")
+def delete_llm_api_key(name: str, username: str = Depends(require_auth)):
+    """Remove a named key (case-insensitive). If it was the active selection,
+    clear the ref so resolution falls back to the legacy env key."""
+    def _apply(entries):
+        return [e for e in entries if isinstance(e, dict)
+                and e.get("name", "").lower() != name.lower()]
+
+    mutate_llm_api_keys(_apply)
     ref = get_setting("llm_api_key_ref")
-    return {
-        "keys": list_named_api_keys(),
-        "selected": ref if isinstance(ref, str) else "",
-        "legacy_key_set": bool(get_setting("llm_api_key")),
-        "model": model,
-        "model_provider": provider,
-    }
+    if isinstance(ref, str) and ref.lower() == name.lower():
+        set_setting("llm_api_key_ref", "")
+    return _api_keys_payload()
+
+
+@router.put("/settings/llm-api-keys/selected")
+def set_selected_llm_api_key(body: SelectedKeyUpdate, username: str = Depends(require_auth)):
+    """Set the active key by name (empty string clears). Validates membership so
+    the ref can't point at a nonexistent entry."""
+    name = body.name.strip()
+    if name:
+        names = {e.get("name", "").lower() for e in list_llm_api_keys() if isinstance(e, dict)}
+        if name.lower() not in names:
+            raise HTTPException(status_code=400, detail=f"No API key named {name!r}")
+    set_setting("llm_api_key_ref", name)
+    return _api_keys_payload()
 
 
 @router.get("/settings/env-overrides")

--- a/backend/config.py
+++ b/backend/config.py
@@ -1,6 +1,5 @@
 import json
 import os
-import re
 import logging
 from typing import Any
 
@@ -15,7 +14,6 @@ DEFAULTS: dict[str, Any] = {
     "business_tax_ids": [],
     "reference_currency": "ILS",
     "llm_model": "gemini/gemini-3-flash-preview",
-    "llm_api_key": "",
     "llm_api_key_ref": "",
     "llm_temperature": 1.0,
     "llm_max_tokens": 8192,
@@ -81,46 +79,150 @@ DEFAULTS: dict[str, Any] = {
 }
 
 SENSITIVE_KEYS = {
-    "llm_api_key", "auth_password_hash", "telegram_bot_token", "gmail_app_password",
+    "auth_password_hash", "telegram_bot_token", "gmail_app_password",
     "gdrive_client_secret", "onedrive_client_secret",
     "cloud_auth_gdrive_token", "cloud_auth_onedrive_token", "cloud_auth_state",
 }
 
-
-# Named provider API keys: RECEIPTORY_LLM_API_KEY_<LABEL> (e.g. _GEMINI, _OPENAI,
-# _TOGETHERAI). The suffix labels which provider a key is for; the user picks one
-# (llm_api_key_ref) to match the selected model. Distinct from the legacy
-# single-key RECEIPTORY_LLM_API_KEY (no suffix), which stays the fallback.
-_NAMED_API_KEY_RE = re.compile(r"^RECEIPTORY_LLM_API_KEY_(.+)$")
+# The single legacy env fallback key, provider-agnostic. Read at startup to seed
+# the DB list (once), and read at resolve time only when no DB key is selected.
+# The RECEIPTORY_LLM_API_KEY_<LABEL> named scheme is retired (issue #25).
+_LEGACY_ENV_KEY = "RECEIPTORY_LLM_API_KEY"
 
 
-def list_named_api_keys() -> list[str]:
-    """Labels of non-empty RECEIPTORY_LLM_API_KEY_<LABEL> env vars (values never
-    exposed). Drives the API-key picker."""
-    out = []
-    for k, v in os.environ.items():
-        m = _NAMED_API_KEY_RE.match(k)
-        if m and v:
-            out.append(m.group(1))
-    return sorted(out)
+def _get_raw_setting(key: str, default: Any) -> Any:
+    """Read a DB-only setting that is NOT in DEFAULTS (e.g. `llm_api_keys`,
+    `llm_api_keys_migrated`). Unlike `get_setting`, this never consults env and
+    never applies the env>db>default precedence — those keys hold secret or
+    control state that must live in the DB alone. Returns `default` if absent."""
+    with get_connection() as conn:
+        row = conn.execute("SELECT value FROM settings WHERE key = ?", (key,)).fetchone()
+        if row is not None:
+            try:
+                return json.loads(row["value"])
+            except (ValueError, TypeError):
+                # A corrupt/hand-edited value must not 500 the settings API or
+                # crash key resolution mid-processing — degrade to the default.
+                logger.warning("Corrupt JSON in settings[%r]; using default", key)
+                return default
+    return default
+
+
+def provider_of(model: str | None) -> str | None:
+    """litellm provider slug for a model id (e.g. 'gemini/gemini-3-flash' ->
+    'gemini'), or None if it can't be resolved. Used to name an imported legacy
+    key and to match a key to the selected model."""
+    if not model:
+        return None
+    try:
+        import litellm
+        return litellm.get_llm_provider(model=model)[1]
+    except Exception:
+        return None
+
+
+def list_llm_api_keys() -> list[dict]:
+    """The DB-stored named API keys: [{"name", "key"}]. Key material included —
+    callers that expose this to clients MUST mask it (see the API layer)."""
+    keys = _get_raw_setting("llm_api_keys", [])
+    return keys if isinstance(keys, list) else []
 
 
 def resolve_llm_api_key() -> str:
-    """The API key to send to litellm. If a named key is selected
-    (llm_api_key_ref) and present in the environment, use it; otherwise fall
-    back to the legacy single llm_api_key (env > db)."""
-    # The ref lookup is best-effort: if the DB isn't available (e.g. an early
-    # env-only code path), fall straight through to the legacy key rather than
-    # letting a RuntimeError escape — the legacy read preserves prior behavior.
+    """The API key to send to litellm.
+
+    Precedence is INVERTED from the app-wide env>db rule, on purpose: a key
+    selected in the UI (llm_api_key_ref -> a DB llm_api_keys entry) wins over the
+    legacy env key, so an `.env` value can never silently mask a UI edit. Only if
+    no valid DB selection exists do we fall back to the single legacy env key.
+    """
+    # Narrow guard: tolerate the DB being unavailable on an early env-only path,
+    # but do NOT swallow arbitrary errors — a transient failure must not silently
+    # send the wrong (legacy) provider's key.
     try:
         ref = get_setting("llm_api_key_ref")
-    except Exception:
-        ref = ""
+        entries = list_llm_api_keys()
+    except RuntimeError:
+        ref, entries = "", []
     if isinstance(ref, str) and ref:
-        v = os.environ.get(f"RECEIPTORY_LLM_API_KEY_{ref}")
-        if v:
-            return v
-    return get_setting("llm_api_key") or ""
+        # Names are case-insensitive identifiers everywhere they're mutated
+        # (add/delete/select), so match the ref the same way here — otherwise a
+        # casing drift between ref and the stored entry silently drops the
+        # selected key and falls back to the wrong (legacy) provider's key.
+        for e in entries:
+            if isinstance(e, dict) and e.get("name", "").lower() == ref.lower() and e.get("key"):
+                return e["key"]
+    return os.environ.get(_LEGACY_ENV_KEY) or ""
+
+
+def set_llm_api_keys(entries: list[dict]) -> None:
+    """Overwrite the DB named-key list. Prefer `mutate_llm_api_keys` for
+    read-then-write edits so the two halves can't interleave."""
+    set_setting("llm_api_keys", entries)
+
+
+def mutate_llm_api_keys(fn) -> list[dict]:
+    """Atomically read-modify-write the named-key list. `fn(entries)` receives the
+    current list and returns the new one.
+
+    The read and write run in one `BEGIN IMMEDIATE` transaction: IMMEDIATE takes
+    the write lock up front (a plain DEFERRED txn wouldn't lock at SELECT time),
+    so two concurrent callers — FastAPI runs sync endpoints in a threadpool, and
+    `get_connection` opens a fresh connection with no process-level lock — can't
+    read the same snapshot and lose an update. Returns the written list."""
+    with get_connection() as conn:
+        conn.execute("BEGIN IMMEDIATE")
+        row = conn.execute("SELECT value FROM settings WHERE key = ?", ("llm_api_keys",)).fetchone()
+        try:
+            current = json.loads(row["value"]) if row is not None else []
+        except (ValueError, TypeError):
+            current = []
+        if not isinstance(current, list):
+            current = []
+        updated = fn(current)
+        conn.execute(
+            """INSERT INTO settings (key, value, updated_at)
+               VALUES (?, ?, strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
+               ON CONFLICT(key) DO UPDATE SET
+                   value = excluded.value, updated_at = excluded.updated_at""",
+            ("llm_api_keys", json.dumps(updated)),
+        )
+        return updated
+
+
+def migrate_llm_api_keys() -> None:
+    """One-time import of env-based keys into the DB list, gated by a dedicated
+    `llm_api_keys_migrated` flag (NOT an empty-list check: after the user deletes
+    all keys in the UI the list is empty again, and a still-present `.env` value
+    would wrongly re-seed on restart). Imports the legacy single key (named after
+    the current model's provider) and any surviving RECEIPTORY_LLM_API_KEY_<LABEL>
+    vars, then sets the flag regardless of whether anything was imported."""
+    if _get_raw_setting("llm_api_keys_migrated", False):
+        return
+    imported: list[dict] = []
+    seen: set[str] = set()
+    legacy = os.environ.get(_LEGACY_ENV_KEY)
+    if legacy:
+        name = (provider_of(get_setting("llm_model")) or "default").title()
+        imported.append({"name": name, "key": legacy})
+        seen.add(name.lower())
+    for k, v in os.environ.items():
+        if k.startswith("RECEIPTORY_LLM_API_KEY_") and v:
+            label = k[len("RECEIPTORY_LLM_API_KEY_"):]
+            # RECEIPTORY_LLM_API_KEY_REF is the env override for the
+            # llm_api_key_ref SETTING (a selection name), not a key — skip it.
+            if label == "REF":
+                continue
+            if label.lower() not in seen:
+                imported.append({"name": label, "key": v})
+                seen.add(label.lower())
+    if imported:
+        set_llm_api_keys(imported)
+        if not get_setting("llm_api_key_ref"):
+            model_provider = (provider_of(get_setting("llm_model")) or "").lower()
+            best = next((e["name"] for e in imported if e["name"].lower() == model_provider), None)
+            set_setting("llm_api_key_ref", best or imported[0]["name"])
+    set_setting("llm_api_keys_migrated", True)
 
 
 def get_setting(key: str) -> Any:

--- a/backend/main.py
+++ b/backend/main.py
@@ -9,7 +9,7 @@ from fastapi.responses import FileResponse
 from fastapi.staticfiles import StaticFiles
 
 from backend.database import init_db
-from backend.config import init_settings
+from backend.config import init_settings, migrate_llm_api_keys
 
 logger = logging.getLogger(__name__)
 
@@ -28,6 +28,7 @@ def create_app(data_dir: str | None = None, run_background: bool = True) -> Fast
         db_path = os.path.join(data_dir, "receiptory.db")
         init_db(db_path)
         init_settings()
+        migrate_llm_api_keys()  # one-time env -> DB key import (issue #25)
 
     @asynccontextmanager
     async def lifespan(app: FastAPI):

--- a/backend/models.py
+++ b/backend/models.py
@@ -176,6 +176,17 @@ class SettingsUpdate(BaseModel):
     settings: dict[str, Any]
 
 
+class ApiKeyCreate(BaseModel):
+    """Add or replace a named LLM API key (issue #25). Same name replaces."""
+    name: str
+    key: str
+
+
+class SelectedKeyUpdate(BaseModel):
+    """Set the active LLM API key by name; empty string clears the selection."""
+    name: str
+
+
 # === Stats ===
 
 class DashboardStats(BaseModel):

--- a/docs/plans/2026-07-22-issue25-db-managed-llm-keys.md
+++ b/docs/plans/2026-07-22-issue25-db-managed-llm-keys.md
@@ -1,0 +1,233 @@
+# Plan: DB-managed LLM API keys (issue #25)
+
+Move LLM provider API keys entirely into the DB as a named, UI-editable list.
+Retire the env-based `RECEIPTORY_LLM_API_KEY_<LABEL>` named-key scheme. Keep the
+single legacy `RECEIPTORY_LLM_API_KEY` as a provider-agnostic fallback.
+
+## Decisions (from eng review 2026-07-22)
+
+1. **Key plumbing — dedicated endpoints, `llm_api_keys` NOT in DEFAULTS.**
+   Generic `GET /settings` and `PATCH /settings` never see key material, so they
+   can neither leak it nor clobber it. `llm_api_key_ref` stays in DEFAULTS (it is
+   a non-secret name).
+2. **Migration — auto-import on startup** (once, when the DB list is empty).
+3. **Integrity — override model.** Names unique; add-with-existing-name replaces
+   the value (rotate). Delete removes the DB entry and, if it was selected,
+   clears the ref. Resolution falls back to the legacy env key, then empty.
+4. **Env fallback — single legacy key only.** `RECEIPTORY_LLM_API_KEY_<LABEL>`
+   scheme is retired. Env is read once at startup to seed the DB, then ignored.
+
+## Data model
+
+```
+setting "llm_api_keys"  (NOT in DEFAULTS; raw DB row, default [])
+  = [ { "name": "Gemini", "key": "AIza..." },
+      { "name": "OpenAI", "key": "sk-proj-..." } ]
+
+setting "llm_api_key_ref"  (in DEFAULTS, default "")  = "Gemini"   # selected name
+```
+
+## Resolution (backend/config.py::resolve_llm_api_key)
+
+```
+                        ┌─────────────────────────────────────────┐
+                        │ resolve_llm_api_key()                    │
+                        └─────────────────────────────────────────┘
+                                        │
+             ref = get_setting("llm_api_key_ref")   # in DEFAULTS
+                                        │
+              ┌─────────────────────────┴─────────────────────────┐
+        ref non-empty AND                                    otherwise
+        name found in db llm_api_keys                             │
+              │                                                   │
+        return entry.key   ◄── DB WINS over env      legacy = RECEIPTORY_LLM_API_KEY
+        (inverted env>db, intentional:                    (env > db, get_setting)
+         UI is authoritative for keys)                          │
+                                                        legacy ? return legacy : ""
+```
+
+Note the **inverted precedence**: for keys specifically, a selected DB entry wins
+over env. Everywhere else the app is env > db. This is deliberate — the UI must be
+authoritative so an `.env` value can't silently mask a UI edit. Add a code comment
+saying so (this is a known past-pain class in this repo).
+
+**Single source of truth (finding #5).** The legacy `llm_api_key` DEFAULTS entry is
+retired — it is no longer written and no longer read as a DB value; the only DB
+home for key material is `llm_api_keys`. The legacy path reads *env only*
+(`RECEIPTORY_LLM_API_KEY`), so there is exactly one DB representation of keys.
+Remove `llm_api_key` from DEFAULTS and from `SENSITIVE_KEYS` masking.
+
+**Narrow the try/except (finding #7).** The `get_setting("llm_api_key_ref")` guard
+must catch only the DB-unavailable case, not swallow every exception — a transient
+error should not silently fall through to the (now env-only) legacy key and send a
+wrong provider's key. Wrap only the ref+list read; let unexpected errors surface.
+
+## Startup migration (backend/config.py, called from init path)
+
+```
+if not get_setting("llm_api_keys_migrated"):          # dedicated flag, NOT empty-list
+    imported = []
+    # legacy single key -> name inferred from the current model's provider
+    if env RECEIPTORY_LLM_API_KEY:
+        name = provider_of(get_setting("llm_model")) or "default"   # e.g. "gemini" -> "Gemini"
+        imported += [{name, key: env RECEIPTORY_LLM_API_KEY}]
+    # named env keys -> LABEL as name  (read ONCE; scheme retired after)
+    for LABEL, val in RECEIPTORY_LLM_API_KEY_<LABEL> in env:
+        imported += [{name: LABEL, key: val}]     # dedupe names, first wins
+    if imported:
+        set_setting("llm_api_keys", imported)
+        if not get_setting("llm_api_key_ref"):
+            # select the imported key whose name/provider matches the model, else first
+            set_setting("llm_api_key_ref", best_match or imported[0].name)
+    set_setting("llm_api_keys_migrated", True)        # set regardless of import result
+```
+
+**Idempotency via a dedicated `llm_api_keys_migrated` flag, not an empty list**
+(outside-voice finding #2). An empty-list guard is wrong: after the user imports
+keys and then deletes them all in the UI, the list is empty again — so on the
+next restart the still-present `.env` values would silently re-seed. The flag is
+set once (even when nothing was imported) and never re-runs. `llm_api_keys_migrated`
+is NOT in DEFAULTS and is read via `_get_raw_setting` (bool, default False).
+
+## API (backend/api/settings.py)
+
+- `GET  /settings/llm-api-keys` → `{ keys: [{name, last4}], selected, model, model_provider, legacy_env_key_set }`
+  (never returns key material; `last4` = last 4 chars for UI disambiguation).
+- `POST /settings/llm-api-keys` body `{name, key}` → add or **replace** by name.
+  Validation (finding #6): trim `name`; reject empty `name` or empty `key` (400);
+  **case-insensitive name match** so "OpenAI" replaces "openai" rather than
+  creating a collision (store the first-seen casing, or the newest — pick newest so
+  a re-add can fix casing). Returns updated `{keys, selected}`.
+- `DELETE /settings/llm-api-keys/{name}` → remove entry (case-insensitive match);
+  if it was the selected ref, clear ref. Returns updated `{keys, selected}`.
+- `PUT  /settings/llm-api-keys/selected` body `{name|""}` → set ref; validate the
+  name exists in the list (empty clears, 400 on unknown name). A dedicated setter
+  (not PATCH /settings) so we can validate membership.
+- Remove env-scan branch from the existing endpoint; `legacy_env_key_set` is now
+  `bool(RECEIPTORY_LLM_API_KEY in env)` for the read-only fallback hint, decoupled
+  from the retired label scheme.
+- **All four mutating reads+writes run inside a single `get_connection()`
+  transaction** (finding #4) so the read-modify-write on the JSON list can't
+  interleave under FastAPI's sync-endpoint threadpool.
+
+## Removed code
+
+- `backend/config.py`: `_NAMED_API_KEY_RE`, `list_named_api_keys()`, the per-label
+  env lookup inside `resolve_llm_api_key`.
+- `backend/api/settings.py`: import of `list_named_api_keys`; env-label payload.
+- `.env` / `.env.example`: the `RECEIPTORY_LLM_API_KEY_<LABEL>` lines and docs.
+- `frontend`: the "(not found in .env)" option and env-label picker branch.
+
+## Frontend (frontend/src/pages/SettingsPage.tsx)
+
+Settings → LLM Engine, replace the env-label picker with a key manager:
+- List rows: `name` · `••••last4` · [radio: active] · [Delete].
+- "Add / update key" row: name input + key input (type=password) + Save
+  (POST). Same name replaces.
+- Active selector writes the ref (PUT selected).
+- Keep a read-only "legacy env key detected" hint when `RECEIPTORY_LLM_API_KEY`
+  is set and no DB key is selected (so the fallback state is visible).
+- All key reads/writes go through `/settings/llm-api-keys`, never generic settings.
+
+## DB write concurrency
+
+`mutate_llm_api_keys` does read-modify-write on the JSON list. `get_connection`
+opens a fresh connection with NO process-level lock and a DEFERRED transaction
+(SELECT takes no write lock), so wrapping the read+write in one `with` block is
+NOT sufficient — two threadpool callers could read the same snapshot and lose an
+update. The mutation issues `BEGIN IMMEDIATE` so the write lock is taken up front
+and the RMW is genuinely serialized. (Caught in /review adversarial pass; the
+single-user UI makes the race unrealistic, but the fix makes the claim true.)
+
+## NOT in scope
+
+- Encrypting key material at rest in the DB, or excluding it from backups. Tracked
+  as a TODO (below); accepted for now on a single-user NAS backing up to the
+  owner's own Drive.
+- Per-model automatic key selection by litellm. The app resolves exactly one key
+  and passes it explicitly; the user picks which via the ref.
+- Multiple keys per provider / key rotation history. One named entry per name.
+
+## What already exists (reused, not rebuilt)
+
+- `settings` table + `get_setting`/`set_setting` JSON upsert — the storage layer.
+- `scanner_active_config` — precedent for a structured-JSON setting.
+- `llm_api_key_ref` setting + Settings → LLM Engine picker UI — repurposed from the
+  env-label scheme to select among DB entries.
+- `get_connection()` context manager with per-context commit + threading lock.
+- Write-only secret handling pattern (GET masks, dedicated mutators) from #13.
+- `resolve_llm_api_key()` call site in `litellm.completion(api_key=...)` — unchanged
+  signature, new internals.
+
+## Failure modes
+
+| Condition | Behavior |
+|---|---|
+| ref set, name missing from list (deleted) | fall through to legacy env key, else "" |
+| list empty, no env key | resolve returns "" → `test-llm`/processing raises "No API key configured" |
+| DB unavailable during resolve | narrow guard → legacy env read; unexpected errors surface (not swallowed) |
+| POST empty name or key | 400, list unchanged |
+| POST name case-collision | replaces existing entry, does not duplicate |
+| user deletes all keys, env still set | flag already set → no re-seed; resolve uses env legacy |
+| restart after migration | flag set → migration skipped entirely |
+
+## TODOS
+
+- [ ] **Secrets in DB backups** — `backend/backup/runner.py:23` copies raw
+  `receiptory.db`, so DB-stored keys leave the box in every backup (`.env` never
+  did). Accepted for single-user NAS now; revisit with column-level encryption or a
+  backup-time key scrub if the threat model changes.
+
+## GSTACK REVIEW REPORT
+
+**Verdict:** APPROVE WITH CHANGES → all folded in above. Ready to implement.
+
+**Scope challenge (Step 0):** Simpler alternative considered — keep keys in `.env`,
+add only a UI *selector*. Rejected: the user's explicit goal is UI-editable keys
+with no new env vars, and a selector-only design can't add a key without editing
+`.env`. Current scope is the minimum that meets the intent.
+
+**Architecture (4 decisions, locked with user):**
+1. Dedicated endpoints; `llm_api_keys` NOT in DEFAULTS → generic GET/PATCH can't
+   leak or clobber key material. ✔
+2. Auto-import from env on first startup, gated by `llm_api_keys_migrated` flag. ✔
+3. Override integrity model — unique (case-insensitive) names, add replaces,
+   delete clears ref if selected. ✔
+4. Single legacy env key only; `_<LABEL>` scheme retired. ✔
+
+**Code Quality:** add `_get_raw_setting(key, default)` helper for non-DEFAULTS DB
+reads (`llm_api_keys`, `llm_api_keys_migrated`); keeps `get_setting` semantics
+(env>db>default over DEFAULTS) uncorrupted.
+
+**Test Coverage (required):**
+- `resolve` env-inversion: selected DB key wins over `RECEIPTORY_LLM_API_KEY`.
+- `resolve` fallback chain: ref-missing → legacy env → "".
+- **Leak guard:** `GET /settings` payload contains no key material; `GET
+  /settings/llm-api-keys` returns only name+last4, never full keys.
+- Migration idempotency: second `init` does not re-seed after keys deleted.
+- Migration seeding: legacy + named env keys imported once, ref auto-selected.
+- POST: add, replace-by-name, case-insensitive replace, empty-name 400, empty-key 400.
+- DELETE: removes entry, clears ref when it was selected.
+- PUT selected: sets ref, 400 on unknown name, "" clears.
+
+**Performance:** read-modify-write on JSON list wrapped in one transaction per
+mutation (finding #4). No hot-path cost — resolve does one indexed settings read.
+
+**Outside-voice findings folded:** #1 (backups → TODO, accepted), #2 (migration
+flag), #4 (transaction), #5 (single source of truth), #6 (POST validation +
+case-norm), #7 (narrow try/except). #3/#8 no action needed.
+
+## Implementation tasks
+
+1. `backend/config.py`: remove `_NAMED_API_KEY_RE`, `list_named_api_keys`, `llm_api_key`
+   from DEFAULTS + SENSITIVE_KEYS. Add `_get_raw_setting`, `llm_api_keys` accessors,
+   `provider_of` helper, rewrite `resolve_llm_api_key` (narrow guard), add
+   `migrate_llm_api_keys()` (flag-gated). Add `llm_api_keys_migrated` handling.
+2. `backend/main.py` (or init path): call `migrate_llm_api_keys()` after `init_settings()`.
+3. `backend/api/settings.py`: rewrite `GET /settings/llm-api-keys`; add `POST`,
+   `DELETE /{name}`, `PUT /selected`; drop `list_named_api_keys` import.
+4. `backend/models.py`: add request models (`ApiKeyCreate{name,key}`, `SelectedUpdate{name}`).
+5. `frontend/src/pages/SettingsPage.tsx`: replace env-label picker with key-manager
+   rows (name · ••••last4 · radio · delete) + add/update row + legacy-hint.
+6. `.env` / `.env.example`: remove `RECEIPTORY_LLM_API_KEY_OPENAI` line + label docs.
+7. Tests: `tests/test_config.py`, `tests/test_settings_api.py` per coverage list.

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -52,6 +52,8 @@ export const api = {
     request<T>(path, { method: "POST", body: body ? JSON.stringify(body) : undefined }),
   patch: <T>(path: string, body: unknown) =>
     request<T>(path, { method: "PATCH", body: JSON.stringify(body) }),
+  put: <T>(path: string, body: unknown) =>
+    request<T>(path, { method: "PUT", body: JSON.stringify(body) }),
   delete: <T>(path: string) => request<T>(path, { method: "DELETE" }),
   upload: async (files: File[]) => {
     const form = new FormData();

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -97,7 +97,11 @@ export default function SettingsPage() {
   const [modelInfo, setModelInfo] = useState<any>(null);
   const [models, setModels] = useState<ModelOption[]>([]);
   const [envKeys, setEnvKeys] = useState<string[]>([]);
-  const [apiKeyLabels, setApiKeyLabels] = useState<string[]>([]);
+  const [apiKeys, setApiKeys] = useState<{ name: string; last4: string }[]>([]);
+  const [apiKeySelected, setApiKeySelected] = useState<string>("");
+  const [legacyEnvKeySet, setLegacyEnvKeySet] = useState<boolean>(false);
+  const [newKeyName, setNewKeyName] = useState<string>("");
+  const [newKeyValue, setNewKeyValue] = useState<string>("");
 
   // Load the vision-capable chat model registry once for the picker (#13, PR3).
   // Cached server-side; failure just leaves the combobox as a free-text field.
@@ -106,9 +110,31 @@ export default function SettingsPage() {
     // Which settings are pinned by an env var (env > db). Edits to these are
     // silently discarded, so the UI shows them read-only instead (#13).
     api.get("/settings/env-overrides").then((r: any) => setEnvKeys(r.keys || [])).catch(() => setEnvKeys([]));
-    // Named provider API keys from .env (RECEIPTORY_LLM_API_KEY_<LABEL>) for the picker (#13).
-    api.get("/settings/llm-api-keys").then((r: any) => setApiKeyLabels(r.keys || [])).catch(() => setApiKeyLabels([]));
+    loadApiKeys();
   }, []);
+
+  // DB-managed LLM API keys (issue #25): name + last4 only, never full secrets.
+  const loadApiKeys = () =>
+    api.get("/settings/llm-api-keys").then((r: any) => {
+      setApiKeys(r.keys || []);
+      setApiKeySelected(r.selected || "");
+      setLegacyEnvKeySet(!!r.legacy_env_key_set);
+    }).catch(() => { setApiKeys([]); setApiKeySelected(""); });
+
+  const addApiKey = async () => {
+    if (!newKeyName.trim() || !newKeyValue.trim()) return;
+    await api.post("/settings/llm-api-keys", { name: newKeyName.trim(), key: newKeyValue.trim() });
+    setNewKeyName(""); setNewKeyValue("");
+    await loadApiKeys();
+  };
+  const deleteApiKey = async (name: string) => {
+    await api.delete(`/settings/llm-api-keys/${encodeURIComponent(name)}`);
+    await loadApiKeys();
+  };
+  const selectApiKey = async (name: string) => {
+    await api.put("/settings/llm-api-keys/selected", { name });
+    await loadApiKeys();
+  };
 
   const envLocked = (k: string) => envKeys.includes(k);
   const envHint = (k: string, base?: string) =>
@@ -348,38 +374,68 @@ export default function SettingsPage() {
                       </div>
                     )}
                   </FieldGroup>
-                  {(apiKeyLabels.length > 0 || (typeof settings.llm_api_key_ref === "string" && settings.llm_api_key_ref)) && (
-                    <FieldGroup
-                      label="Provider Key (from .env)"
-                      hint={
-                        `Named keys defined as RECEIPTORY_LLM_API_KEY_<LABEL> in .env.` +
-                        (modelInfo && modelInfo.model === settings.llm_model && modelInfo.provider
-                          ? ` Selected model provider: ${modelInfo.provider} — pick the matching key.`
-                          : "")
-                      }
-                    >
-                      <select
-                        className={`${inputCls} w-full px-3`}
-                        value={typeof settings.llm_api_key_ref === "string" ? settings.llm_api_key_ref : ""}
-                        onChange={(e) => { setSettings({ ...settings, llm_api_key_ref: e.target.value }); save({ llm_api_key_ref: e.target.value }); }}
-                      >
-                        <option value="">Use single key below</option>
-                        {apiKeyLabels.map((k) => <option key={k} value={k}>{k}</option>)}
-                        {typeof settings.llm_api_key_ref === "string" && settings.llm_api_key_ref && !apiKeyLabels.includes(settings.llm_api_key_ref) && (
-                          <option value={settings.llm_api_key_ref}>{settings.llm_api_key_ref} (not found in .env)</option>
-                        )}
-                      </select>
-                    </FieldGroup>
-                  )}
                   <FieldGroup
-                    label="API Key"
+                    label="API Keys"
                     hint={
-                      (typeof settings.llm_api_key_ref === "string" && settings.llm_api_key_ref)
-                        ? `Overridden by the selected provider key "${settings.llm_api_key_ref}". Set the picker to "Use single key below" to use this field.`
-                        : envHint("llm_api_key")
+                      `Provider keys are stored in the database and editable here. The selected key is sent to the model.` +
+                      (modelInfo && modelInfo.model === settings.llm_model && modelInfo.provider
+                        ? ` Selected model provider: ${modelInfo.provider} — pick the matching key.`
+                        : "")
                     }
                   >
-                    <Input className={inputCls} type="password" disabled={envLocked("llm_api_key") || !!(typeof settings.llm_api_key_ref === "string" && settings.llm_api_key_ref)} value={settings.llm_api_key || ""} onBlur={(e) => { if (e.target.value && !e.target.value.includes("***")) save({ llm_api_key: e.target.value }); }} onChange={(e) => setSettings({ ...settings, llm_api_key: e.target.value })} />
+                    <div className="flex flex-col gap-2">
+                      {apiKeys.length === 0 && (
+                        <p className="text-[12px] text-muted-foreground">No API keys stored yet. Add one below.</p>
+                      )}
+                      {apiKeys.map((k) => (
+                        <div key={k.name} className="flex items-center gap-2 rounded-md border px-3 py-2">
+                          <input
+                            type="radio"
+                            name="apiKeySelected"
+                            checked={apiKeySelected.toLowerCase() === k.name.toLowerCase()}
+                            onChange={() => selectApiKey(k.name)}
+                            title="Use this key"
+                          />
+                          <span className="font-medium text-[13px]">{k.name}</span>
+                          <span className="font-mono text-[12px] text-muted-foreground">••••{k.last4}</span>
+                          <button
+                            type="button"
+                            className="ml-auto text-[12px] text-red-500 hover:underline"
+                            onClick={() => deleteApiKey(k.name)}
+                          >
+                            Delete
+                          </button>
+                        </div>
+                      ))}
+                      <div className="flex items-center gap-2 pt-1">
+                        <Input
+                          className={`${inputCls} w-40`}
+                          placeholder="Name (e.g. Gemini)"
+                          value={newKeyName}
+                          onChange={(e) => setNewKeyName(e.target.value)}
+                        />
+                        <Input
+                          className={`${inputCls} flex-1`}
+                          type="password"
+                          placeholder="API key"
+                          value={newKeyValue}
+                          onChange={(e) => setNewKeyValue(e.target.value)}
+                        />
+                        <button
+                          type="button"
+                          className="px-4 py-2 bg-primary text-white text-sm font-bold rounded-lg shadow-md hover:opacity-90 transition-opacity disabled:opacity-50 disabled:cursor-not-allowed"
+                          onClick={addApiKey}
+                          disabled={!newKeyName.trim() || !newKeyValue.trim()}
+                        >
+                          Save
+                        </button>
+                      </div>
+                      {legacyEnvKeySet && !apiKeySelected && (
+                        <p className="text-[11px] text-muted-foreground">
+                          No key selected — falling back to RECEIPTORY_LLM_API_KEY from .env.
+                        </p>
+                      )}
+                    </div>
                   </FieldGroup>
                   <FieldGroup label="Temperature" hint={envHint("llm_temperature", "Gemini 3 is tuned for 1.0. Lower values can degrade extraction quality.")}>
                     <Input className={inputCls} type="number" step="0.1" min="0" max="2" disabled={envLocked("llm_temperature")} value={settings.llm_temperature ?? 1} onBlur={(e) => save({ llm_temperature: parseFloat(e.target.value) })} onChange={(e) => setSettings({ ...settings, llm_temperature: e.target.value })} />

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -52,11 +52,11 @@ def test_get_all_settings(db_path):
     assert "auth_username" in settings
 
 def test_masked_settings(db_path):
-    set_setting("llm_api_key", "sk-secret-key-12345")
+    set_setting("telegram_bot_token", "sk-secret-key-12345")
     from backend.config import get_all_settings_masked
     settings = get_all_settings_masked()
-    assert settings["llm_api_key"] != "sk-secret-key-12345"
-    assert "***" in settings["llm_api_key"]
+    assert settings["telegram_bot_token"] != "sk-secret-key-12345"
+    assert "***" in settings["telegram_bot_token"]
 
 def test_init_settings_seeds_defaults(db_path):
     init_settings()
@@ -66,34 +66,88 @@ def test_init_settings_seeds_defaults(db_path):
         assert row is not None
 
 
-# --- Named provider API keys (#13) ---
+# --- DB-managed LLM API keys (#25) ---
 
-def test_list_named_api_keys_filters_empty_and_legacy(db_path, monkeypatch):
-    from backend.config import list_named_api_keys
-    monkeypatch.setenv("RECEIPTORY_LLM_API_KEY_GEMINI", "gk")
-    monkeypatch.setenv("RECEIPTORY_LLM_API_KEY_OPENAI", "sk")
-    monkeypatch.setenv("RECEIPTORY_LLM_API_KEY_EMPTY", "")   # empty -> excluded
-    monkeypatch.setenv("RECEIPTORY_LLM_API_KEY", "legacy")   # no suffix -> excluded
-    assert list_named_api_keys() == ["GEMINI", "OPENAI"]
-
-
-def test_resolve_llm_api_key_uses_selected_named_key(db_path, monkeypatch):
-    from backend.config import resolve_llm_api_key
-    monkeypatch.setenv("RECEIPTORY_LLM_API_KEY_OPENAI", "sk-openai")
-    set_setting("llm_api_key_ref", "OPENAI")
-    set_setting("llm_api_key", "legacy-gemini")
+def test_resolve_selected_db_key_wins_over_env(db_path, monkeypatch):
+    """The INVERTED precedence: a UI-selected DB key beats the legacy env key."""
+    from backend.config import resolve_llm_api_key, set_llm_api_keys
+    monkeypatch.setenv("RECEIPTORY_LLM_API_KEY", "env-legacy")
+    set_llm_api_keys([{"name": "OpenAI", "key": "sk-openai"}])
+    set_setting("llm_api_key_ref", "OpenAI")
     assert resolve_llm_api_key() == "sk-openai"
 
 
-def test_resolve_llm_api_key_falls_back_to_legacy_when_ref_missing(db_path, monkeypatch):
-    from backend.config import resolve_llm_api_key
-    # ref points at a label with no env var present -> legacy key.
-    set_setting("llm_api_key_ref", "GHOST")
-    set_setting("llm_api_key", "legacy-key")
-    assert resolve_llm_api_key() == "legacy-key"
+def test_resolve_falls_back_to_legacy_env_when_ref_missing(db_path, monkeypatch):
+    """ref names a deleted/absent entry -> fall through to the legacy env key."""
+    from backend.config import resolve_llm_api_key, set_llm_api_keys
+    monkeypatch.setenv("RECEIPTORY_LLM_API_KEY", "env-legacy")
+    set_llm_api_keys([{"name": "Gemini", "key": "gk"}])
+    set_setting("llm_api_key_ref", "Ghost")
+    assert resolve_llm_api_key() == "env-legacy"
 
 
-def test_resolve_llm_api_key_no_ref_uses_legacy(db_path):
+def test_resolve_no_ref_no_env_is_empty(db_path):
     from backend.config import resolve_llm_api_key
-    set_setting("llm_api_key", "legacy-key")
-    assert resolve_llm_api_key() == "legacy-key"
+    assert resolve_llm_api_key() == ""
+
+
+def test_resolve_ref_match_is_case_insensitive(db_path):
+    """Names are case-insensitive identifiers everywhere they're mutated; resolve
+    must match the same way so a casing drift doesn't silently drop the key."""
+    from backend.config import resolve_llm_api_key, set_llm_api_keys
+    set_llm_api_keys([{"name": "OpenAI", "key": "sk-openai"}])
+    set_setting("llm_api_key_ref", "openai")   # different casing than stored
+    assert resolve_llm_api_key() == "sk-openai"
+
+
+def test_resolve_no_ref_uses_legacy_env(db_path, monkeypatch):
+    from backend.config import resolve_llm_api_key
+    monkeypatch.setenv("RECEIPTORY_LLM_API_KEY", "env-legacy")
+    assert resolve_llm_api_key() == "env-legacy"
+
+
+def test_migrate_imports_legacy_and_named_env_keys_once(db_path, monkeypatch):
+    from backend.config import migrate_llm_api_keys, list_llm_api_keys
+    monkeypatch.setenv("RECEIPTORY_LLM_API_KEY", "gk")
+    monkeypatch.setenv("RECEIPTORY_LLM_API_KEY_OPENAI", "sk-openai")
+    set_setting("llm_model", "gemini/gemini-3-flash-preview")
+    migrate_llm_api_keys()
+    names = {e["name"] for e in list_llm_api_keys()}
+    assert "OpenAI" in names or "OPENAI" in names
+    assert any(e["key"] == "gk" for e in list_llm_api_keys())
+    assert get_setting("llm_api_key_ref")  # a key was auto-selected
+
+
+def test_migrate_skips_ref_env_var(db_path, monkeypatch):
+    """RECEIPTORY_LLM_API_KEY_REF is the ref-selection override, not a key —
+    it must not be imported as a bogus 'REF' key."""
+    from backend.config import migrate_llm_api_keys, list_llm_api_keys
+    monkeypatch.setenv("RECEIPTORY_LLM_API_KEY_REF", "OpenAI")
+    monkeypatch.setenv("RECEIPTORY_LLM_API_KEY_OPENAI", "sk-openai")
+    migrate_llm_api_keys()
+    names = {e["name"] for e in list_llm_api_keys()}
+    assert "REF" not in names
+    assert "OPENAI" in names
+
+
+def test_get_raw_setting_tolerates_corrupt_json(db_path):
+    """A corrupt stored value degrades to the default instead of crashing."""
+    from backend.config import _get_raw_setting
+    from backend.database import get_connection
+    with get_connection() as conn:
+        conn.execute(
+            "INSERT INTO settings (key, value, updated_at) VALUES ('llm_api_keys', 'not-json', 'now')"
+        )
+    assert _get_raw_setting("llm_api_keys", []) == []
+
+
+def test_migrate_is_idempotent_after_keys_deleted(db_path, monkeypatch):
+    """The flag (not empty-list) guards re-seeding: deleting all keys then
+    restarting must NOT re-import from a still-present .env."""
+    from backend.config import migrate_llm_api_keys, list_llm_api_keys, set_llm_api_keys
+    monkeypatch.setenv("RECEIPTORY_LLM_API_KEY", "gk")
+    migrate_llm_api_keys()
+    assert len(list_llm_api_keys()) == 1
+    set_llm_api_keys([])            # user deletes the last key in the UI
+    migrate_llm_api_keys()          # simulate restart
+    assert list_llm_api_keys() == []

--- a/tests/test_settings_api.py
+++ b/tests/test_settings_api.py
@@ -133,18 +133,54 @@ def test_env_overrides_requires_auth(app):
     assert resp.status_code == 401
 
 
-def test_llm_api_keys_lists_labels_and_provider(authed_client, monkeypatch):
-    # PR: named provider keys picker (#13). Labels only, never values.
-    monkeypatch.setenv("RECEIPTORY_LLM_API_KEY_GEMINI", "gk")
-    monkeypatch.setenv("RECEIPTORY_LLM_API_KEY_OPENAI", "sk")
-    resp = authed_client.get("/api/settings/llm-api-keys")
+def test_llm_api_keys_add_list_and_mask(authed_client):
+    # DB-managed keys (#25): add returns name + last4 only, never the secret.
+    resp = authed_client.post("/api/settings/llm-api-keys", json={"name": "OpenAI", "key": "sk-secret-123456"})
     assert resp.status_code == 200
     data = resp.json()
-    assert data["keys"] == ["GEMINI", "OPENAI"]
+    assert data["keys"] == [{"name": "OpenAI", "last4": "3456"}]
     # default model is gemini/* -> provider resolves to gemini
     assert data["model_provider"] == "gemini"
-    # secret values are never returned
-    assert "gk" not in resp.text and "sk" not in resp.text
+    # secret value is never returned
+    assert "sk-secret-123456" not in resp.text
+    assert "secret" not in resp.text
+
+
+def test_settings_get_never_leaks_key_material(authed_client):
+    authed_client.post("/api/settings/llm-api-keys", json={"name": "OpenAI", "key": "sk-verysecret-abcdef"})
+    resp = authed_client.get("/api/settings")
+    assert "sk-verysecret-abcdef" not in resp.text
+    assert "verysecret" not in resp.text
+
+
+def test_llm_api_keys_replace_by_name_case_insensitive(authed_client):
+    authed_client.post("/api/settings/llm-api-keys", json={"name": "openai", "key": "sk-old-1111"})
+    resp = authed_client.post("/api/settings/llm-api-keys", json={"name": "OpenAI", "key": "sk-new-2222"})
+    keys = resp.json()["keys"]
+    assert len(keys) == 1
+    assert keys[0]["name"] == "OpenAI" and keys[0]["last4"] == "2222"
+
+
+def test_llm_api_keys_rejects_empty_name_or_key(authed_client):
+    assert authed_client.post("/api/settings/llm-api-keys", json={"name": "  ", "key": "sk-x"}).status_code == 400
+    assert authed_client.post("/api/settings/llm-api-keys", json={"name": "OpenAI", "key": ""}).status_code == 400
+
+
+def test_llm_api_keys_rejects_slash_in_name(authed_client):
+    # A slash would make the entry unreachable by the DELETE path route.
+    assert authed_client.post("/api/settings/llm-api-keys", json={"name": "a/b", "key": "sk-x"}).status_code == 400
+
+
+def test_llm_api_keys_select_and_delete_clears_ref(authed_client):
+    authed_client.post("/api/settings/llm-api-keys", json={"name": "Gemini", "key": "gk-1234"})
+    sel = authed_client.put("/api/settings/llm-api-keys/selected", json={"name": "Gemini"})
+    assert sel.status_code == 200 and sel.json()["selected"] == "Gemini"
+    # unknown selection is rejected
+    assert authed_client.put("/api/settings/llm-api-keys/selected", json={"name": "Ghost"}).status_code == 400
+    # deleting the selected key clears the ref
+    dele = authed_client.delete("/api/settings/llm-api-keys/Gemini")
+    assert dele.status_code == 200
+    assert dele.json()["keys"] == [] and dele.json()["selected"] == ""
 
 
 def test_llm_api_keys_requires_auth(app):


### PR DESCRIPTION
Closes #25.

## What

Move LLM provider API keys out of env vars and into the SQLite `settings` table as a named, UI-editable list (`llm_api_keys = [{name, key}]`). Retire the `RECEIPTORY_LLM_API_KEY_<LABEL>` scheme; keep the single legacy `RECEIPTORY_LLM_API_KEY` as a provider-agnostic fallback. No new env vars.

## How it resolves

`resolve_llm_api_key()` prefers a UI-selected DB key (`llm_api_key_ref` → a `llm_api_keys` entry) over env — an **intentional inversion** of the app-wide env>db rule, so an `.env` value can never silently mask a UI edit. Only when no valid DB selection exists does it fall back to the legacy env key, then empty.

## Migration

One-time env→DB import on startup, gated by a dedicated `llm_api_keys_migrated` flag (not an empty-list check — deleting all keys in the UI must not re-seed from a lingering `.env` on restart). Imports the legacy key (named after the model's provider) and any surviving `RECEIPTORY_LLM_API_KEY_<LABEL>` vars; skips `RECEIPTORY_LLM_API_KEY_REF`.

## API (all auth-gated, never return key material)

- `GET /settings/llm-api-keys` → name + last4 only, selection, model provider, legacy-env hint
- `POST` add/replace by name (case-insensitive, validates name/key, rejects `/`)
- `DELETE /{name}` (clears ref if it was selected)
- `PUT /selected` (validates membership)

## Frontend

Settings → LLM Engine gets a key manager: rows (name · ••••last4 · active radio · delete), an add/update row, and a legacy-fallback hint.

## Safety / correctness (from /review adversarial pass)

- `mutate_llm_api_keys` serializes the read-modify-write with `BEGIN IMMEDIATE` (a plain DEFERRED txn takes no write lock at SELECT time; `get_connection` holds no process lock).
- Names are case-insensitive identifiers end to end (add/delete/select/resolve/radio).
- Corrupt stored JSON degrades to default instead of 500-ing the settings API or crashing document processing.

## Known tradeoff (accepted, single-user NAS)

API keys now live in the DB, so they are included in raw DB backups (`backend/backup/runner.py` copies `receiptory.db`). `.env` never left the box. Tracked as a TODO in the plan doc; acceptable for a single-user self-hosted deployment backing up to the owner's own Drive.

## Verification

- 297 backend tests pass (net +6 for this feature: env-inversion, migration idempotency, leak guard, case-insensitive replace/resolve, POST validation, corrupt-JSON tolerance).
- Frontend `tsc --noEmit` clean; production build succeeds.
- `BEGIN IMMEDIATE` interaction verified empirically (no nested-transaction error).

## Post-merge (deploy)

`.env` on the NAS still has `RECEIPTORY_LLM_API_KEY_OPENAI` so the migration imports both keys on first startup of this branch. After confirming "OpenAI" appears under Settings → LLM Engine → API Keys, that line can be deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)