### PR TITLE
fix(ingestion): capture Adobe canvas-viewer PDFs from URL fetch

### DIFF
--- a/backend/ingestion/url_fetcher.py
+++ b/backend/ingestion/url_fetcher.py
@@ -7,6 +7,7 @@ Fetch pipeline (stops at first success):
 4. Playwright render with auth wall detection and page capture fallback
 """
 
+import asyncio
 import logging
 import re
 import socket
@@ -82,7 +83,7 @@ class FetchResult:
     content_type: str  # MIME type
     original_url: str  # Source URL
     auth_wall: bool = False  # True if login page detected
-    method: str = ""  # "direct", "link_follow", "playwright_download", "playwright_capture"
+    method: str = ""  # "direct", "link_follow", "playwright_download", "playwright_network", "playwright_capture"
 
 
 def _ext_for_content_type(content_type: str) -> str:
@@ -160,6 +161,66 @@ async def _follow_link(
     return None
 
 
+# Minimum seconds to allow for browser rendering. A full SPA (e.g. the
+# Adobe Acrobat viewer) needs far longer than a direct HTTP fetch, so the
+# short httpx timeout must not starve page.goto.
+_MIN_RENDER_TIMEOUT = 30
+
+# Seconds to wait after load for a canvas-based viewer to stream its document.
+_DOC_STREAM_SETTLE = 10
+
+# Seconds to wait for any PDF stream to *begin* before treating the page as an
+# ordinary (non-viewer) page and bailing out of the settle loop early.
+_DOC_STREAM_DETECT = 5
+
+# Hard cap on a captured PDF response body — a malicious page could stream an
+# arbitrarily large application/pdf and OOM the single-process NAS deployment.
+_MAX_CAPTURE_BYTES = 50 * 1024 * 1024
+
+
+async def _read_streamed_pdf(page, pdf_responses: list) -> bytes | None:
+    """Wait (bounded) for a canvas viewer to stream a PDF, return its bytes.
+
+    Polls the responses collected by the page's response listener. Canvas
+    viewers fire the document request right after "load", so we first wait a
+    short window for any application/pdf response to appear; if none does, this
+    is an ordinary page and we return fast rather than stalling the fallback
+    path. Once a response exists we keep polling (its body resolves quickly).
+
+    Each body read is timeout-bounded and attempted at most once per response:
+    the processing queue is single-process and sequential, so an unbounded (or
+    repeated) await on a stalled stream would hang all document processing, not
+    just this fetch. response.body() already waits for the body to complete, so
+    a response that times out or errors once will not succeed on a retry.
+    """
+    tried: set = set()
+    for i in range(_DOC_STREAM_SETTLE):
+        for resp in list(pdf_responses):
+            if id(resp) in tried:
+                continue
+            tried.add(id(resp))
+            try:
+                body = await asyncio.wait_for(
+                    resp.body(), timeout=_DOC_STREAM_SETTLE
+                )
+            except Exception:
+                continue
+            if body:
+                if len(body) > _MAX_CAPTURE_BYTES:
+                    logger.warning(
+                        "Captured PDF exceeds %d bytes (%d); discarding: %s",
+                        _MAX_CAPTURE_BYTES, len(body), getattr(resp, "url", "?"),
+                    )
+                    continue
+                return body
+        # No PDF has even started streaming within the detect window — this is
+        # a normal page, so don't wait out the full settle window.
+        if not pdf_responses and i >= _DOC_STREAM_DETECT:
+            return None
+        await page.wait_for_timeout(1000)
+    return None
+
+
 async def _playwright_fetch(
     url: str, download_dir: str, timeout: int, user_agent: str | None = None,
 ) -> FetchResult | None:
@@ -171,6 +232,36 @@ async def _playwright_fetch(
             "playwright is not installed; skipping browser-based fetch for %s", url
         )
         return None
+
+    # Browser rendering needs more time than a direct fetch; floor the timeout.
+    nav_timeout = max(int(timeout), _MIN_RENDER_TIMEOUT)
+
+    # Canvas-based PDF viewers (Adobe Acrobat share links, etc.) never expose
+    # the document as an <a> link and render nothing capturable via page.pdf();
+    # they stream the real bytes as an application/pdf network response. Collect
+    # those responses so we can save the actual document.
+    pdf_responses: list = []
+
+    def _on_response(resp) -> None:
+        try:
+            ct = resp.headers.get("content-type", "").split(";")[0].strip().lower()
+            if ct != "application/pdf":
+                return
+            # The browser fetches sub-resources from any host during render;
+            # apply the same SSRF gate as the top-level URL so a rendered page
+            # can't cause us to persist an internal endpoint's bytes.
+            if not _is_safe_url(resp.url):
+                logger.warning("Skipping captured PDF from unsafe host: %s", resp.url)
+                return
+            # Cheap size guard when the server declares a length (the read in
+            # _read_streamed_pdf enforces the cap for chunked responses too).
+            clen = resp.headers.get("content-length", "")
+            if clen.isdigit() and int(clen) > _MAX_CAPTURE_BYTES:
+                logger.warning("Skipping oversized captured PDF (%s bytes): %s", clen, resp.url)
+                return
+            pdf_responses.append(resp)
+        except Exception:
+            pass
 
     try:
         async with async_playwright() as pw:
@@ -184,7 +275,37 @@ async def _playwright_fetch(
                     viewport=viewport,
                     is_mobile=is_mobile,
                 )
-                await page.goto(url, timeout=timeout * 1000, wait_until="networkidle")
+                page.on("response", _on_response)
+                # "networkidle" never settles on SPAs that poll or stream
+                # (the Adobe viewer keeps connections open indefinitely), so
+                # goto would always time out. Wait for "load" instead.
+                await page.goto(url, timeout=nav_timeout * 1000, wait_until="load")
+
+                # Give a canvas-based viewer a bounded window to stream its
+                # document, then save the first readable PDF response.
+                streamed_pdf = await _read_streamed_pdf(page, pdf_responses)
+                page.remove_listener("response", _on_response)
+                if streamed_pdf:
+                    file_path = _save_response(
+                        streamed_pdf, "application/pdf", download_dir
+                    )
+                    return FetchResult(
+                        file_path=file_path,
+                        content_type="application/pdf",
+                        original_url=url,
+                        method="playwright_network",
+                    )
+
+                # A PDF stream was detected but its bytes were unreadable
+                # (stalled, evicted, or over the size cap). This is a canvas
+                # viewer whose document we couldn't capture — treat it as a
+                # fetch failure rather than filing a blank page.pdf() capture
+                # of the viewer shell as if it were the real document.
+                if pdf_responses:
+                    logger.warning(
+                        "PDF stream detected for %s but no readable body; not capturing blank page", url
+                    )
+                    return None
 
                 # Auth wall detection
                 password_fields = await page.query_selector_all(

--- a/tests/test_url_fetcher.py
+++ b/tests/test_url_fetcher.py
@@ -309,3 +309,192 @@ class TestPlaywrightFetchImportError:
                 "https://example.com", str(tmp_path), timeout=5
             )
         assert result is None
+
+
+def _make_playwright_mock(page):
+    """Build an async_playwright() mock whose page is `page`."""
+    browser = MagicMock()
+    browser.new_page = AsyncMock(return_value=page)
+    browser.close = AsyncMock()
+
+    pw = MagicMock()
+    pw.chromium = MagicMock()
+    pw.chromium.launch = AsyncMock(return_value=browser)
+
+    pw_cm = MagicMock()
+    pw_cm.__aenter__ = AsyncMock(return_value=pw)
+    pw_cm.__aexit__ = AsyncMock(return_value=False)
+    return MagicMock(return_value=pw_cm)
+
+
+def _fake_pdf_response(body: bytes = b"%PDF-1.4 doc", url: str = "https://cdn.example.com/doc.pdf"):
+    """A mock Playwright Response for a streamed application/pdf."""
+    resp = MagicMock()
+    resp.url = url
+    resp.headers = {"content-type": "application/pdf"}
+    resp.body = AsyncMock(return_value=body)
+    return resp
+
+
+def _streaming_page(fake_resp=None):
+    """A mock Playwright Page that fires `fake_resp` to its response listener
+    during goto (simulating a canvas viewer streaming its PDF)."""
+    handlers: dict = {}
+    page = MagicMock()
+    page.on = MagicMock(side_effect=lambda evt, cb: handlers.__setitem__(evt, cb))
+
+    async def fake_goto(url, **kwargs):
+        if fake_resp is not None and "response" in handlers:
+            handlers["response"](fake_resp)
+
+    page.goto = AsyncMock(side_effect=fake_goto)
+    page.wait_for_timeout = AsyncMock()
+    page.query_selector_all = AsyncMock(return_value=[])
+    page.content = AsyncMock(return_value="<html></html>")
+    page.pdf = AsyncMock(return_value=b"%PDF-1.4 page capture")
+    return page
+
+
+@pytest.mark.asyncio
+class TestPlaywrightNetworkPdfCapture:
+    """Regression: canvas-based viewers (Adobe Acrobat share links) stream the
+    real document as an application/pdf response and never expose it via an <a>
+    link or page.pdf(). The fetcher must intercept that response.
+
+    Also guards against the networkidle regression: Adobe's viewer keeps
+    connections open forever, so wait_until must not be "networkidle".
+    """
+
+    async def test_streamed_pdf_is_captured(self, tmp_path):
+        pdf_bytes = b"%PDF-1.4 real adobe document bytes"
+        page = _streaming_page(_fake_pdf_response(body=pdf_bytes))
+
+        with patch(
+            "playwright.async_api.async_playwright",
+            _make_playwright_mock(page),
+        ), patch("backend.ingestion.url_fetcher._is_safe_url", return_value=True):
+            result = await _playwright_fetch(
+                "https://acrobat.adobe.com/id/urn:aaid:sc:AP:test",
+                str(tmp_path),
+                timeout=5,
+            )
+
+        # The streamed PDF is saved, not the blank page.pdf() capture.
+        assert result is not None
+        assert result.content_type == "application/pdf"
+        assert result.method == "playwright_network"
+        assert Path(result.file_path).read_bytes() == pdf_bytes
+
+        # Guard the networkidle regression that caused the original failure.
+        assert page.goto.call_args.kwargs.get("wait_until") == "load"
+        # Browser render timeout must be floored well above the 5s http timeout.
+        assert page.goto.call_args.kwargs.get("timeout", 0) >= 30_000
+
+    async def test_streamed_pdf_body_error_returns_none(self, tmp_path):
+        # A canvas viewer streams a PDF response, but its body can't be read
+        # (stalled/evicted). We must NOT file a blank page.pdf() capture as if
+        # it were the real document — return None (fetch failure) instead.
+        resp = _fake_pdf_response()
+        resp.body = AsyncMock(side_effect=Exception("body not available"))
+        page = _streaming_page(resp)
+
+        with patch(
+            "playwright.async_api.async_playwright",
+            _make_playwright_mock(page),
+        ), patch("backend.ingestion.url_fetcher._is_safe_url", return_value=True):
+            result = await _playwright_fetch(
+                "https://acrobat.adobe.com/id/urn:aaid:sc:AP:test",
+                str(tmp_path),
+                timeout=5,
+            )
+
+        assert result is None
+        page.pdf.assert_not_awaited()
+        # A stalled/erroring body must be attempted once, not re-awaited every
+        # settle iteration (which would multiply the worst-case hang).
+        assert resp.body.await_count == 1
+
+    async def test_streamed_pdf_from_unsafe_host_is_skipped(self, tmp_path):
+        # A rendered page streaming application/pdf from an internal host must
+        # not be captured (SSRF); it falls through to the page.pdf() capture.
+        page = _streaming_page(_fake_pdf_response(body=b"internal secret pdf"))
+
+        with patch(
+            "playwright.async_api.async_playwright",
+            _make_playwright_mock(page),
+        ), patch("backend.ingestion.url_fetcher._is_safe_url", return_value=False):
+            result = await _playwright_fetch(
+                "https://example.com/viewer", str(tmp_path), timeout=5
+            )
+
+        assert result is not None
+        assert result.method == "playwright_capture"
+        assert Path(result.file_path).read_bytes() == b"%PDF-1.4 page capture"
+
+    async def test_oversized_streamed_pdf_discarded(self, tmp_path):
+        # A PDF body over the size cap is discarded (OOM guard); with no other
+        # readable body, the fetch fails rather than capturing a blank page.
+        from backend.ingestion import url_fetcher
+
+        big = b"x" * 32
+        page = _streaming_page(_fake_pdf_response(body=big))
+
+        with patch(
+            "playwright.async_api.async_playwright",
+            _make_playwright_mock(page),
+        ), patch("backend.ingestion.url_fetcher._is_safe_url", return_value=True), \
+                patch.object(url_fetcher, "_MAX_CAPTURE_BYTES", 16):
+            result = await _playwright_fetch(
+                "https://acrobat.adobe.com/id/urn:aaid:sc:AP:test",
+                str(tmp_path),
+                timeout=5,
+            )
+
+        assert result is None
+
+    async def test_falls_back_to_page_capture_when_no_pdf_streamed(self, tmp_path):
+        # No application/pdf response and no document links -> page.pdf() capture.
+        page = MagicMock()
+        page.on = MagicMock()
+        page.goto = AsyncMock()
+        page.wait_for_timeout = AsyncMock()
+        page.query_selector_all = AsyncMock(return_value=[])
+        page.content = AsyncMock(return_value="<html><body>no links</body></html>")
+        page.pdf = AsyncMock(return_value=b"%PDF-1.4 page capture")
+
+        with patch(
+            "playwright.async_api.async_playwright",
+            _make_playwright_mock(page),
+        ):
+            result = await _playwright_fetch(
+                "https://example.com/viewer", str(tmp_path), timeout=5
+            )
+
+        assert result is not None
+        assert result.method == "playwright_capture"
+        assert Path(result.file_path).read_bytes() == b"%PDF-1.4 page capture"
+
+    async def test_no_pdf_bails_early_without_full_settle(self, tmp_path):
+        # A page that never streams a PDF must not wait out the full settle
+        # window before falling through to the capture path.
+        from backend.ingestion import url_fetcher
+
+        page = MagicMock()
+        page.on = MagicMock()
+        page.goto = AsyncMock()
+        page.wait_for_timeout = AsyncMock()
+        page.query_selector_all = AsyncMock(return_value=[])
+        page.content = AsyncMock(return_value="<html><body>plain</body></html>")
+        page.pdf = AsyncMock(return_value=b"%PDF-1.4 page capture")
+
+        with patch(
+            "playwright.async_api.async_playwright",
+            _make_playwright_mock(page),
+        ):
+            await _playwright_fetch(
+                "https://example.com/viewer", str(tmp_path), timeout=5
+            )
+
+        # Bailed at the detect window, not the full settle window.
+        assert page.wait_for_timeout.await_count == url_fetcher._DOC_STREAM_DETECT
+        assert url_fetcher._DOC_STREAM_DETECT < url_fetcher._DOC_STREAM_SETTLE


### PR DESCRIPTION
## Problem

Adobe Acrobat share links (`acrobat.adobe.com/id/urn:aaid:...`) submitted via Telegram failed to import — no document record was created at all. 6/6 such URLs failed over 07-17 and 07-22; zero were ever ingested.

Root cause, two layers in `_playwright_fetch`:
1. `page.goto` used `wait_until="networkidle"`, which never settles on the Adobe viewer's streaming SPA. `goto` timed out at 5s → `fetch_url` returned `None` → nothing filed. Reproduced: `networkidle` times out even at 30s; `load` succeeds in ~5s.
2. Even past the timeout, the viewer renders the PDF in a canvas, so the DOM link-scan finds nothing and `page.pdf()` captures a blank page. The real document is streamed as an `application/pdf` network response, which the code ignored.

## Fix (`backend/ingestion/url_fetcher.py`)

- `wait_until` `networkidle` → `load`, with a 30s floored render timeout decoupled from the short httpx fetch timeout.
- Intercept the streamed `application/pdf` response and save the real bytes (`method="playwright_network"`); bail early (~5s) on ordinary non-viewer pages.
- Bound each body read with `asyncio.wait_for` and attempt each response once, so a stalled stream can't hang the single-process sequential queue.
- Re-check `_is_safe_url` on captured responses (SSRF), cap captured body size (OOM guard), and return `None` instead of filing a blank `page.pdf()` capture when a PDF stream was detected but unreadable.

## Verification

- End-to-end against a live Adobe share link: real receipt PDF recovered (1 page, 428 chars) in ~6s.
- Full suite: **303 passed** (2m37s). Adds 6 regression tests over mocked Playwright covering capture, wait-condition/timeout guards, early-bail, body-error → None, SSRF-host skip, and oversized-body discard.

## Notes

- Reviewed across three `/review` rounds (specialist army + adversarial). Surfaced and fixed: queue-hang on unbounded body read, silent blank-doc filing, and a 100s retry-amplification bug.
- One accepted pre-existing pattern (not changed): `_is_safe_url` does a blocking DNS lookup, consistent with its existing call in `fetch_url`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)