### PR TITLE
feat(ingestion): add remote receipt intake

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -47,6 +47,14 @@
 # RECEIPTORY_WATCHED_FOLDER_PATH=/path/to/watched/folder
 # RECEIPTORY_WATCHED_FOLDER_POLL_INTERVAL=10  # seconds
 
+# --- Remote intake (outbound polling; disabled by default) ---
+# RECEIPTORY_REMOTE_INTAKE_ENABLED=false
+# RECEIPTORY_REMOTE_INTAKE_BASE_URL=https://receipts.example.com
+# RECEIPTORY_REMOTE_INTAKE_TOKEN=dedicated-random-bearer-token
+# RECEIPTORY_REMOTE_INTAKE_POLL_INTERVAL_SECONDS=10
+# RECEIPTORY_REMOTE_INTAKE_BATCH_SIZE=10
+# RECEIPTORY_REMOTE_INTAKE_MAX_FILE_BYTES=20971520  # 20 MiB
+
 # --- Backup (rclone) ---
 # RECEIPTORY_BACKUP_DESTINATION=              # rclone remote, e.g. gcs:my-bucket/receiptory
 # RECEIPTORY_BACKUP_SCHEDULE=0 2 * * *       # cron expression

--- a/README.md
+++ b/README.md
@@ -171,6 +171,12 @@ Most settings are configurable via the admin UI. Environment variables take prec
 | `RECEIPTORY_PORT` | `8484` | HTTP port |
 | `RECEIPTORY_DATA_DIR` | `./data` | Data directory (DB, files, logs) |
 | `RECEIPTORY_TELEGRAM_BOT_TOKEN` | — | Telegram bot token from @BotFather |
+| `RECEIPTORY_REMOTE_INTAKE_ENABLED` | `false` | Enable outbound polling of a hosted receipt queue |
+| `RECEIPTORY_REMOTE_INTAKE_BASE_URL` | — | Fixed HTTPS origin and optional path prefix for the queue |
+| `RECEIPTORY_REMOTE_INTAKE_TOKEN` | — | Dedicated queue bearer token |
+| `RECEIPTORY_REMOTE_INTAKE_POLL_INTERVAL_SECONDS` | `10` | Normal polling interval |
+| `RECEIPTORY_REMOTE_INTAKE_BATCH_SIZE` | `10` | Maximum items requested per cycle |
+| `RECEIPTORY_REMOTE_INTAKE_MAX_FILE_BYTES` | `20971520` | Maximum downloaded file size |
 | `RECEIPTORY_GMAIL_ADDRESS` | — | Gmail address to poll via IMAP |
 | `RECEIPTORY_GMAIL_APP_PASSWORD` | — | Gmail App Password (16 chars) |
 | `RECEIPTORY_BACKUP_SCHEDULE` | `0 2 * * *` | Backup cron schedule |
@@ -190,6 +196,62 @@ See `.env.example` for the full list with descriptions.
 3. Restart the container
 4. Optionally restrict access by adding your Telegram user ID (message [@userinfobot](https://t.me/userinfobot) to find it)
 5. Send or forward photos/documents to your bot
+
+### Remote Intake
+
+Remote intake lets another application submit receipts without exposing
+Receiptory or Umbrel to inbound internet traffic. Receiptory polls a fixed
+hosted queue over HTTPS, downloads bounded files, ingests them through the same
+content-hash deduplication path as browser and Telegram uploads, and then
+acknowledges the result. It is disabled by default and configurable in
+Administration > Remote Intake or with the environment variables above.
+
+Every queue request uses:
+
+```http
+Authorization: Bearer <dedicated-token>
+```
+
+The queue contract is:
+
+```http
+GET <base>/v1/receiptory/items?limit=<batch-size>
+GET <base>/v1/receiptory/items/<percent-encoded-id>/content
+POST <base>/v1/receiptory/items/<percent-encoded-id>/ack
+```
+
+The list response has this shape:
+
+```json
+{
+  "items": [
+    {
+      "id": "stable-opaque-id",
+      "filename": "receipt.jpg",
+      "content_type": "image/jpeg",
+      "sender_identifier": "optional-worker-reference"
+    }
+  ]
+}
+```
+
+The acknowledgement body is one of:
+
+```json
+{"status":"accepted","document_id":123}
+{"status":"duplicate","document_id":123}
+{"status":"rejected","detail":"unsupported media type"}
+```
+
+Items remain pending until a successful acknowledgement, so delivery is at
+least once. If an acknowledgement is lost, the next delivery is identified as
+a duplicate by SHA-256 and acknowledged with the existing document ID. The
+queue base URL must use HTTPS; loopback HTTP is accepted only for local tests.
+All protocol endpoints stay under the configured origin and path prefix, and
+item-provided download URLs are never followed.
+
+Use a dedicated random bearer token with access only to these queue endpoints.
+Do **not** give Receiptory a Supabase service-role key.
 
 ### Gmail
 

--- a/backend/api/upload.py
+++ b/backend/api/upload.py
@@ -5,7 +5,7 @@ from fastapi import APIRouter, UploadFile, File, Depends, Request
 
 from backend.auth import require_auth
 from backend.database import get_connection
-from backend.storage import compute_file_hash, save_original
+from backend.ingestion.service import ingest_local_file
 
 logger = logging.getLogger(__name__)
 
@@ -31,36 +31,24 @@ async def upload_files(
             tmp_path = tmp.name
 
         try:
-            file_hash = compute_file_hash(tmp_path)
-            file_size = len(content)
-            ext = os.path.splitext(upload.filename or ".pdf")[1].lower()
-
-            # Check for duplicate
-            with get_connection() as conn:
-                existing = conn.execute(
-                    "SELECT id FROM documents WHERE file_hash = ?", (file_hash,)
-                ).fetchone()
-
-            if existing:
+            result = ingest_local_file(
+                tmp_path,
+                filename=upload.filename or "document.pdf",
+                data_dir=data_dir,
+                submission_channel="web_upload",
+            )
+            if result.status == "duplicate":
                 duplicates.append({
                     "filename": upload.filename,
-                    "file_hash": file_hash,
-                    "existing_id": existing["id"],
+                    "file_hash": result.file_hash,
+                    "existing_id": result.document_id,
                 })
                 continue
 
-            # Save original file
-            save_original(tmp_path, file_hash, ext, data_dir)
-
-            # Create document record
             with get_connection() as conn:
-                conn.execute(
-                    """INSERT INTO documents (original_filename, file_hash, file_size_bytes, status, submission_channel)
-                       VALUES (?, ?, ?, 'pending', 'web_upload')""",
-                    (upload.filename, file_hash, file_size),
-                )
-                doc_id = conn.execute("SELECT last_insert_rowid()").fetchone()[0]
-                doc = conn.execute("SELECT * FROM documents WHERE id = ?", (doc_id,)).fetchone()
+                doc = conn.execute(
+                    "SELECT * FROM documents WHERE id = ?", (result.document_id,)
+                ).fetchone()
 
             created.append({
                 "id": doc["id"],
@@ -68,17 +56,6 @@ async def upload_files(
                 "file_hash": doc["file_hash"],
                 "status": doc["status"],
             })
-            try:
-                from backend.notifications.notifier import notify
-                notify("ingested", {
-                    "id": doc["id"],
-                    "original_filename": doc["original_filename"],
-                    "file_hash": doc["file_hash"],
-                    "submission_channel": "web_upload",
-                    "sender_identifier": None,
-                })
-            except Exception:
-                pass
 
         finally:
             os.unlink(tmp_path)

--- a/backend/config.py
+++ b/backend/config.py
@@ -44,6 +44,12 @@ DEFAULTS: dict[str, Any] = {
     "gmail_authorized_senders": [],
     "watched_folder_path": "",
     "watched_folder_poll_interval": 10,
+    "remote_intake_enabled": False,
+    "remote_intake_base_url": "",
+    "remote_intake_token": "",
+    "remote_intake_poll_interval_seconds": 10,
+    "remote_intake_batch_size": 10,
+    "remote_intake_max_file_bytes": 20 * 1024 * 1024,
     "url_fetch_timeout": 5,
     "base_url": "",
     "gdrive_client_id": "",
@@ -82,6 +88,7 @@ SENSITIVE_KEYS = {
     "auth_password_hash", "telegram_bot_token", "gmail_app_password",
     "gdrive_client_secret", "onedrive_client_secret",
     "cloud_auth_gdrive_token", "cloud_auth_onedrive_token", "cloud_auth_state",
+    "remote_intake_token",
 }
 
 # The single legacy env fallback key, provider-agnostic. Read at startup to seed

--- a/backend/ingestion/remote_intake.py
+++ b/backend/ingestion/remote_intake.py
@@ -1,0 +1,311 @@
+import asyncio
+import logging
+import os
+import random
+import tempfile
+from pathlib import Path
+from urllib.parse import quote, urlsplit
+
+import httpx
+from pydantic import BaseModel, Field, ValidationError
+
+from backend.config import get_setting
+from backend.ingestion.service import ingest_local_file
+
+logger = logging.getLogger(__name__)
+
+REQUEST_TIMEOUT = httpx.Timeout(connect=10, read=30, write=30, pool=10)
+ALLOWED_MEDIA_TYPES = {
+    "application/pdf": {".pdf"},
+    "image/jpeg": {".jpg", ".jpeg"},
+    "image/png": {".png"},
+    "image/webp": {".webp"},
+}
+
+
+class RemoteIntakeAuthError(RuntimeError):
+    pass
+
+
+class RemoteItemRejected(ValueError):
+    pass
+
+
+class RemoteItem(BaseModel):
+    id: str = Field(min_length=1, max_length=512)
+    filename: str = Field(min_length=1, max_length=255)
+    content_type: str = Field(min_length=1, max_length=100)
+    sender_identifier: str | None = Field(default=None, max_length=512)
+
+
+class RemoteItemsResponse(BaseModel):
+    items: list[RemoteItem]
+
+
+def validate_remote_base_url(raw: str) -> str:
+    """Return a normalized fixed queue base URL or raise a safe ValueError."""
+    value = raw.strip()
+    parsed = urlsplit(value)
+    if not parsed.scheme or not parsed.netloc or not parsed.hostname:
+        raise ValueError("Remote intake base URL must be absolute")
+    if parsed.username is not None or parsed.password is not None:
+        raise ValueError("Remote intake base URL cannot contain credentials")
+    if parsed.query or parsed.fragment:
+        raise ValueError("Remote intake base URL cannot contain query or fragment")
+    if parsed.scheme == "http":
+        if parsed.hostname not in {"localhost", "127.0.0.1", "::1"}:
+            raise ValueError("Remote intake base URL must use HTTPS")
+    elif parsed.scheme != "https":
+        raise ValueError("Remote intake base URL must use HTTPS")
+    return value.rstrip("/")
+
+
+def _raise_for_queue_status(response: httpx.Response) -> None:
+    if response.status_code in {401, 403}:
+        raise RemoteIntakeAuthError("Remote intake authentication failed")
+    response.raise_for_status()
+
+
+def _item_urls(base_url: str, item_id: str) -> tuple[str, str]:
+    encoded_id = quote(item_id, safe="")
+    item_base = f"{base_url}/v1/receiptory/items/{encoded_id}"
+    return f"{item_base}/content", f"{item_base}/ack"
+
+
+def _validate_item_metadata(item: RemoteItem) -> tuple[str, str]:
+    media_type = item.content_type.split(";", 1)[0].strip().lower()
+    extensions = ALLOWED_MEDIA_TYPES.get(media_type)
+    if not extensions:
+        raise RemoteItemRejected("unsupported media type")
+    filename = os.path.basename(item.filename)
+    extension = Path(filename).suffix.lower()
+    if extension not in extensions:
+        raise RemoteItemRejected("filename extension does not match media type")
+    return filename, media_type
+
+
+def _validate_file_signature(file_path: str, media_type: str) -> None:
+    with open(file_path, "rb") as file:
+        header = file.read(12)
+    valid = {
+        "application/pdf": header.startswith(b"%PDF-"),
+        "image/jpeg": header.startswith(b"\xff\xd8\xff"),
+        "image/png": header.startswith(b"\x89PNG\r\n\x1a\n"),
+        "image/webp": header.startswith(b"RIFF") and header[8:12] == b"WEBP",
+    }[media_type]
+    if not valid:
+        raise RemoteItemRejected("file content does not match media type")
+
+
+async def _download_item(
+    client: httpx.AsyncClient,
+    *,
+    url: str,
+    headers: dict[str, str],
+    extension: str,
+    media_type: str,
+    max_bytes: int,
+) -> str:
+    temp_path = None
+    try:
+        with tempfile.NamedTemporaryFile(delete=False, suffix=extension) as temp:
+            temp_path = temp.name
+            total = 0
+            async with client.stream(
+                "GET", url, headers=headers, timeout=REQUEST_TIMEOUT
+            ) as response:
+                _raise_for_queue_status(response)
+                for_header = response.headers.get("content-type")
+                if for_header:
+                    response_type = for_header.split(";", 1)[0].strip().lower()
+                    if response_type != media_type:
+                        raise RemoteItemRejected(
+                            "response media type does not match item metadata"
+                        )
+                async for chunk in response.aiter_bytes():
+                    total += len(chunk)
+                    if total > max_bytes:
+                        raise RemoteItemRejected(
+                            "file exceeds configured maximum size"
+                        )
+                    temp.write(chunk)
+        if total == 0:
+            raise RemoteItemRejected("empty file")
+        _validate_file_signature(temp_path, media_type)
+        return temp_path
+    except Exception:
+        if temp_path and os.path.exists(temp_path):
+            os.unlink(temp_path)
+        raise
+
+
+async def _acknowledge(
+    client: httpx.AsyncClient,
+    *,
+    url: str,
+    headers: dict[str, str],
+    payload: dict,
+) -> None:
+    response = await client.post(
+        url, headers=headers, json=payload, timeout=REQUEST_TIMEOUT
+    )
+    _raise_for_queue_status(response)
+
+
+async def poll_remote_intake_once(
+    *,
+    data_dir: str,
+    client: httpx.AsyncClient | None = None,
+) -> int:
+    """Process one bounded queue batch and return successful ack count."""
+    if not get_setting("remote_intake_enabled"):
+        return 0
+
+    raw_base_url = get_setting("remote_intake_base_url") or ""
+    token = get_setting("remote_intake_token") or ""
+    if not raw_base_url or not token:
+        logger.warning(
+            "Remote intake is enabled but its base URL or token is not configured"
+        )
+        return 0
+
+    try:
+        base_url = validate_remote_base_url(str(raw_base_url))
+    except ValueError:
+        logger.warning("Remote intake base URL is invalid")
+        return 0
+
+    batch_size = max(1, min(int(get_setting("remote_intake_batch_size") or 10), 100))
+    max_bytes = max(1, int(get_setting("remote_intake_max_file_bytes") or 1))
+    headers = {"Authorization": f"Bearer {token}"}
+    owns_client = client is None
+    if client is None:
+        client = httpx.AsyncClient(timeout=REQUEST_TIMEOUT)
+
+    try:
+        list_response = await client.get(
+            f"{base_url}/v1/receiptory/items",
+            params={"limit": batch_size},
+            headers=headers,
+            timeout=REQUEST_TIMEOUT,
+        )
+        _raise_for_queue_status(list_response)
+        try:
+            items = RemoteItemsResponse.model_validate(list_response.json()).items
+        except (ValueError, ValidationError):
+            logger.warning("Remote intake returned a malformed item list")
+            return 0
+
+        acknowledged = 0
+        for item in items[:batch_size]:
+            content_url, ack_url = _item_urls(base_url, item.id)
+            temp_path = None
+            try:
+                filename, media_type = _validate_item_metadata(item)
+                extension = Path(filename).suffix.lower()
+                temp_path = await _download_item(
+                    client,
+                    url=content_url,
+                    headers=headers,
+                    extension=extension,
+                    media_type=media_type,
+                    max_bytes=max_bytes,
+                )
+                result = await asyncio.to_thread(
+                    ingest_local_file,
+                    temp_path,
+                    filename=filename,
+                    data_dir=data_dir,
+                    submission_channel="remote_intake",
+                    sender_identifier=item.sender_identifier,
+                )
+                await _acknowledge(
+                    client,
+                    url=ack_url,
+                    headers=headers,
+                    payload={
+                        "status": result.status,
+                        "document_id": result.document_id,
+                    },
+                )
+                acknowledged += 1
+            except RemoteItemRejected as error:
+                try:
+                    await _acknowledge(
+                        client,
+                        url=ack_url,
+                        headers=headers,
+                        payload={"status": "rejected", "detail": str(error)},
+                    )
+                    acknowledged += 1
+                except RemoteIntakeAuthError:
+                    raise
+                except httpx.HTTPError:
+                    logger.warning(
+                        "Remote intake could not acknowledge a rejected item"
+                    )
+            except RemoteIntakeAuthError:
+                raise
+            except httpx.HTTPError:
+                logger.warning(
+                    "Remote intake item request failed; it will be retried"
+                )
+            except Exception:
+                logger.warning(
+                    "Remote intake item failed; metadata was omitted from logs"
+                )
+            finally:
+                if temp_path and os.path.exists(temp_path):
+                    os.unlink(temp_path)
+        return acknowledged
+    finally:
+        if owns_client:
+            await client.aclose()
+
+
+def _backoff_delay(
+    failure_count: int,
+    poll_interval: int,
+    *,
+    jitter: float | None = None,
+) -> float:
+    base = min(300.0, float(max(1, poll_interval)) * (2 ** (failure_count - 1)))
+    if jitter is None:
+        jitter = random.uniform(0, min(5.0, base * 0.25))
+    return min(300.0, base + max(0.0, jitter))
+
+
+async def run_remote_intake_poller(data_dir: str) -> None:
+    """Poll forever with bounded backoff until application cancellation."""
+    failures = 0
+    async with httpx.AsyncClient(timeout=REQUEST_TIMEOUT) as client:
+        while True:
+            poll_interval = max(
+                1, int(get_setting("remote_intake_poll_interval_seconds") or 10)
+            )
+            try:
+                await poll_remote_intake_once(data_dir=data_dir, client=client)
+            except asyncio.CancelledError:
+                raise
+            except RemoteIntakeAuthError:
+                failures += 1
+                delay = _backoff_delay(failures, poll_interval)
+                logger.warning(
+                    "Remote intake authentication failed; polling will retry"
+                )
+            except httpx.HTTPError:
+                failures += 1
+                delay = _backoff_delay(failures, poll_interval)
+                logger.warning(
+                    "Remote intake queue request failed; polling will retry"
+                )
+            except Exception:
+                failures += 1
+                delay = _backoff_delay(failures, poll_interval)
+                logger.warning(
+                    "Remote intake polling failed; details were omitted from logs"
+                )
+            else:
+                failures = 0
+                delay = poll_interval
+            await asyncio.sleep(delay)

--- a/backend/ingestion/service.py
+++ b/backend/ingestion/service.py
@@ -1,0 +1,94 @@
+import logging
+import os
+import sqlite3
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal
+
+from backend.database import get_connection
+from backend.storage import compute_file_hash, save_original
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class IngestionResult:
+    status: Literal["accepted", "duplicate"]
+    document_id: int
+    file_hash: str
+
+
+def ingest_local_file(
+    file_path: str,
+    *,
+    filename: str,
+    data_dir: str,
+    submission_channel: str,
+    sender_identifier: str | None = None,
+    source_url: str | None = None,
+    status: str = "pending",
+    user_notes: str | None = None,
+) -> IngestionResult:
+    """Persist one local file as a document, idempotently by SHA-256."""
+    file_hash = compute_file_hash(file_path)
+    file_size = os.path.getsize(file_path)
+    safe_filename = os.path.basename(filename) or "document"
+    extension = Path(safe_filename).suffix.lower() or ".bin"
+
+    with get_connection() as conn:
+        existing = conn.execute(
+            "SELECT id FROM documents WHERE file_hash = ?", (file_hash,)
+        ).fetchone()
+    if existing:
+        return IngestionResult("duplicate", existing["id"], file_hash)
+
+    save_original(file_path, file_hash, extension, data_dir)
+
+    try:
+        with get_connection() as conn:
+            conn.execute(
+                """INSERT INTO documents
+                   (original_filename, file_hash, file_size_bytes, status,
+                    submission_channel, sender_identifier, source_url, user_notes)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
+                (
+                    safe_filename,
+                    file_hash,
+                    file_size,
+                    status,
+                    submission_channel,
+                    sender_identifier,
+                    source_url,
+                    user_notes,
+                ),
+            )
+            document_id = conn.execute("SELECT last_insert_rowid()").fetchone()[0]
+    except sqlite3.IntegrityError:
+        # A concurrent source may have inserted the same content after our
+        # initial lookup. The content-addressed original is safe to share.
+        with get_connection() as conn:
+            existing = conn.execute(
+                "SELECT id FROM documents WHERE file_hash = ?", (file_hash,)
+            ).fetchone()
+        if existing:
+            return IngestionResult("duplicate", existing["id"], file_hash)
+        raise
+
+    try:
+        from backend.notifications.notifier import notify
+
+        notify(
+            "ingested",
+            {
+                "id": document_id,
+                "original_filename": safe_filename,
+                "file_hash": file_hash,
+                "submission_channel": submission_channel,
+                "sender_identifier": sender_identifier,
+                "source_url": source_url,
+            },
+        )
+    except Exception:
+        logger.exception("Ingestion notification failed for document #%s", document_id)
+
+    return IngestionResult("accepted", document_id, file_hash)

--- a/backend/ingestion/telegram.py
+++ b/backend/ingestion/telegram.py
@@ -15,6 +15,7 @@ from telegram.ext import (
 from backend.config import get_setting
 from backend.database import get_connection
 from backend.storage import compute_file_hash, save_original
+from backend.ingestion.service import ingest_local_file
 from backend.ingestion.url_triage import triage_telegram_urls
 from backend.ingestion.url_fetcher import fetch_url
 
@@ -180,6 +181,7 @@ async def _ingest_file(
     if user.username:
         sender = f"telegram:@{user.username}"
 
+    tmp_path = None
     try:
         tg_file = await context.bot.get_file(file_id)
 
@@ -188,53 +190,34 @@ async def _ingest_file(
             await tg_file.download_to_drive(tmp.name)
             tmp_path = tmp.name
 
-        file_hash = compute_file_hash(tmp_path)
-        file_size = os.path.getsize(tmp_path)
-
-        # Check duplicate
-        with get_connection() as conn:
-            existing = conn.execute(
-                "SELECT id FROM documents WHERE file_hash = ?", (file_hash,)
-            ).fetchone()
-
-        if existing:
+        result = ingest_local_file(
+            tmp_path,
+            filename=filename,
+            data_dir=data_dir,
+            submission_channel="telegram",
+            sender_identifier=sender,
+        )
+        if result.status == "duplicate":
             await update.message.reply_text(
-                f"Duplicate file — already exists as document #{existing['id']}."
+                f"Duplicate file — already exists as document #{result.document_id}."
             )
-            os.unlink(tmp_path)
             return
 
-        # Save original
-        save_original(tmp_path, file_hash, ext, data_dir)
-
-        # Create document record
-        with get_connection() as conn:
-            conn.execute(
-                """INSERT INTO documents
-                   (original_filename, file_hash, file_size_bytes, status, submission_channel, sender_identifier)
-                   VALUES (?, ?, ?, 'pending', 'telegram', ?)""",
-                (filename, file_hash, file_size, sender),
-            )
-            doc_id = conn.execute("SELECT last_insert_rowid()").fetchone()[0]
-
-        os.unlink(tmp_path)
-        await update.message.reply_text(f"Received! Document #{doc_id} queued for processing.")
-        logger.info(f"Telegram: ingested {filename} as document #{doc_id} from {sender}")
-        try:
-            from backend.notifications.notifier import notify
-            notify("ingested", {
-                "id": doc_id,
-                "original_filename": filename,
-                "file_hash": file_hash,
-                "submission_channel": "telegram",
-                "sender_identifier": sender,
-            })
-        except Exception:
-            pass
+        await update.message.reply_text(
+            f"Received! Document #{result.document_id} queued for processing."
+        )
+        logger.info(
+            "Telegram: ingested %s as document #%s",
+            filename,
+            result.document_id,
+        )
 
     except Exception as e:
         logger.error(f"Telegram ingestion failed: {e}")
         await update.message.reply_text(f"Failed to process file: {e}")
+    finally:
+        if tmp_path and os.path.exists(tmp_path):
+            os.unlink(tmp_path)
 
 
 def _is_authorized(user_id: int) -> bool:

--- a/backend/main.py
+++ b/backend/main.py
@@ -58,11 +58,21 @@ def create_app(data_dir: str | None = None, run_background: bool = True) -> Fast
             from backend.ingestion.telegram import start_telegram_bot, stop_telegram_bot
             from backend.ingestion.gmail import run_gmail_poller
             from backend.ingestion.watched_folder import run_watched_folder
+            from backend.ingestion.remote_intake import run_remote_intake_poller
             queue_task = asyncio.create_task(run_queue_loop(data_dir))
             backup_task = asyncio.create_task(run_backup_scheduler(data_dir))
             gmail_task = asyncio.create_task(run_gmail_poller(data_dir))
             folder_task = asyncio.create_task(run_watched_folder(data_dir))
-            background_tasks.extend([queue_task, backup_task, gmail_task, folder_task])
+            remote_intake_task = asyncio.create_task(
+                run_remote_intake_poller(data_dir)
+            )
+            background_tasks.extend([
+                queue_task,
+                backup_task,
+                gmail_task,
+                folder_task,
+                remote_intake_task,
+            ])
             await start_telegram_bot(data_dir)
 
         app.state.data_dir = data_dir

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -11,12 +11,13 @@ import BackupPanel from "@/components/BackupPanel";
 import CloudBackupPanel from "@/components/CloudBackupPanel";
 import LogViewer from "@/components/LogViewer";
 
-type SettingsTab = "general" | "llm" | "telegram" | "email" | "categories" | "backup" | "notifications" | "logs";
+type SettingsTab = "general" | "llm" | "telegram" | "remote" | "email" | "categories" | "backup" | "notifications" | "logs";
 
 const TABS: { key: SettingsTab; label: string; icon: string }[] = [
   { key: "general",    label: "General",     icon: "tune" },
   { key: "llm",        label: "LLM Engine",  icon: "psychology" },
   { key: "telegram",   label: "Telegram",    icon: "send" },
+  { key: "remote",     label: "Remote Intake", icon: "cloud_download" },
   { key: "email",      label: "Email",       icon: "mail" },
   { key: "categories", label: "Taxonomies",  icon: "label" },
   { key: "backup",        label: "Resilience",     icon: "backup" },
@@ -587,6 +588,111 @@ export default function SettingsPage() {
                       )}
                     </span>
                   )}
+                </div>
+              </div>
+            </SectionCard>
+          </div>
+        </div>
+      )}
+
+      {/* Remote Intake */}
+      {activeTab === "remote" && (
+        <div className="grid grid-cols-1 lg:grid-cols-12 gap-6">
+          <div className="lg:col-span-8">
+            <SectionCard
+              title="Remote Intake"
+              icon="cloud_download"
+              badge={settings.remote_intake_enabled ? "Enabled" : "Disabled"}
+            >
+              <div className="space-y-4">
+                <div>
+                  <div className="flex items-center gap-3">
+                    <Checkbox
+                      disabled={envLocked("remote_intake_enabled")}
+                      checked={settings.remote_intake_enabled === true}
+                      onCheckedChange={(checked) => save({ remote_intake_enabled: !!checked })}
+                    />
+                    <div>
+                      <Label className="text-sm font-medium">Poll a hosted receipt queue</Label>
+                      <p className="text-xs text-muted-foreground">
+                        Receiptory connects outbound over HTTPS. Umbrel needs no public port or tunnel.
+                      </p>
+                    </div>
+                  </div>
+                  {envLocked("remote_intake_enabled") && (
+                    <p className="text-[11px] text-muted-foreground leading-snug mt-1.5">
+                      {envHint("remote_intake_enabled")}
+                    </p>
+                  )}
+                </div>
+
+                <FieldGroup label="Queue Base URL" hint={envHint("remote_intake_base_url", "HTTPS is required except for localhost testing.")}>
+                  <Input
+                    className={inputCls}
+                    disabled={envLocked("remote_intake_base_url")}
+                    value={settings.remote_intake_base_url || ""}
+                    onBlur={(e) => save({ remote_intake_base_url: e.target.value.trim() })}
+                    onChange={(e) => setSettings({ ...settings, remote_intake_base_url: e.target.value })}
+                    placeholder="https://receipts.example.com"
+                  />
+                </FieldGroup>
+
+                <FieldGroup label="Dedicated Bearer Token" hint={envHint("remote_intake_token", "Use a queue-specific random token, never a Supabase service-role key.")}>
+                  <Input
+                    className={inputCls}
+                    type="password"
+                    disabled={envLocked("remote_intake_token")}
+                    value={settings.remote_intake_token || ""}
+                    onBlur={(e) => {
+                      if (e.target.value && !e.target.value.includes("***")) {
+                        save({ remote_intake_token: e.target.value });
+                      }
+                    }}
+                    onChange={(e) => setSettings({ ...settings, remote_intake_token: e.target.value })}
+                    placeholder="Dedicated queue bearer token"
+                  />
+                </FieldGroup>
+
+                <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+                  <FieldGroup label="Poll Interval (seconds)" hint={envHint("remote_intake_poll_interval_seconds")}>
+                    <Input
+                      className={inputCls}
+                      type="number"
+                      min={1}
+                      disabled={envLocked("remote_intake_poll_interval_seconds")}
+                      value={settings.remote_intake_poll_interval_seconds ?? 10}
+                      onBlur={(e) => save({ remote_intake_poll_interval_seconds: parseInt(e.target.value) || 10 })}
+                      onChange={(e) => setSettings({ ...settings, remote_intake_poll_interval_seconds: e.target.value })}
+                    />
+                  </FieldGroup>
+                  <FieldGroup label="Batch Size" hint={envHint("remote_intake_batch_size")}>
+                    <Input
+                      className={inputCls}
+                      type="number"
+                      min={1}
+                      max={100}
+                      disabled={envLocked("remote_intake_batch_size")}
+                      value={settings.remote_intake_batch_size ?? 10}
+                      onBlur={(e) => save({ remote_intake_batch_size: parseInt(e.target.value) || 10 })}
+                      onChange={(e) => setSettings({ ...settings, remote_intake_batch_size: e.target.value })}
+                    />
+                  </FieldGroup>
+                  <FieldGroup label="Maximum File (MiB)" hint={envHint("remote_intake_max_file_bytes")}>
+                    <Input
+                      className={inputCls}
+                      type="number"
+                      min={1}
+                      disabled={envLocked("remote_intake_max_file_bytes")}
+                      value={Math.max(1, Math.round((settings.remote_intake_max_file_bytes ?? 20 * 1024 * 1024) / (1024 * 1024)))}
+                      onBlur={(e) => save({ remote_intake_max_file_bytes: (parseInt(e.target.value) || 20) * 1024 * 1024 })}
+                      onChange={(e) => setSettings({ ...settings, remote_intake_max_file_bytes: (parseInt(e.target.value) || 1) * 1024 * 1024 })}
+                    />
+                  </FieldGroup>
+                </div>
+
+                <div className="bg-muted rounded-lg p-3 text-xs text-muted-foreground space-y-1">
+                  <p>Accepted formats: PDF, JPEG, PNG, and WebP.</p>
+                  <p>Delivery is at least once; duplicate content is acknowledged by SHA-256 hash.</p>
                 </div>
               </div>
             </SectionCard>

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -66,6 +66,35 @@ def test_init_settings_seeds_defaults(db_path):
         assert row is not None
 
 
+def test_remote_intake_defaults(db_path):
+    assert get_setting("remote_intake_enabled") is False
+    assert get_setting("remote_intake_base_url") == ""
+    assert get_setting("remote_intake_token") == ""
+    assert get_setting("remote_intake_poll_interval_seconds") == 10
+    assert get_setting("remote_intake_batch_size") == 10
+    assert get_setting("remote_intake_max_file_bytes") == 20 * 1024 * 1024
+
+
+def test_remote_intake_env_types(db_path, monkeypatch):
+    monkeypatch.setenv("RECEIPTORY_REMOTE_INTAKE_ENABLED", "true")
+    monkeypatch.setenv("RECEIPTORY_REMOTE_INTAKE_POLL_INTERVAL_SECONDS", "15")
+    monkeypatch.setenv("RECEIPTORY_REMOTE_INTAKE_BATCH_SIZE", "7")
+    monkeypatch.setenv("RECEIPTORY_REMOTE_INTAKE_MAX_FILE_BYTES", "4096")
+    assert get_setting("remote_intake_enabled") is True
+    assert get_setting("remote_intake_poll_interval_seconds") == 15
+    assert get_setting("remote_intake_batch_size") == 7
+    assert get_setting("remote_intake_max_file_bytes") == 4096
+
+
+def test_remote_intake_token_is_masked(db_path):
+    set_setting("remote_intake_token", "worker-queue-secret")
+    from backend.config import get_all_settings_masked
+
+    settings = get_all_settings_masked()
+    assert settings["remote_intake_token"] != "worker-queue-secret"
+    assert "***" in settings["remote_intake_token"]
+
+
 # --- DB-managed LLM API keys (#25) ---
 
 def test_resolve_selected_db_key_wins_over_env(db_path, monkeypatch):

--- a/tests/test_ingestion_service.py
+++ b/tests/test_ingestion_service.py
@@ -1,0 +1,62 @@
+from PIL import Image
+
+from backend.database import get_connection
+
+
+def _write_jpeg(file_path):
+    Image.new("RGB", (8, 8), color=(240, 240, 240)).save(file_path, "JPEG")
+
+
+def test_ingest_local_file_creates_pending_document(db_path, tmp_data_dir):
+    from backend.ingestion.service import ingest_local_file
+
+    source = tmp_data_dir / "incoming.jpg"
+    _write_jpeg(source)
+
+    result = ingest_local_file(
+        str(source),
+        filename="worker-receipt.jpg",
+        data_dir=str(tmp_data_dir),
+        submission_channel="remote_intake",
+        sender_identifier="worker:test",
+    )
+
+    assert result.status == "accepted"
+    assert result.document_id > 0
+    assert (tmp_data_dir / "storage" / "originals" / f"{result.file_hash}.jpg").exists()
+    with get_connection() as conn:
+        document = conn.execute(
+            "SELECT * FROM documents WHERE id = ?", (result.document_id,)
+        ).fetchone()
+    assert document["original_filename"] == "worker-receipt.jpg"
+    assert document["submission_channel"] == "remote_intake"
+    assert document["sender_identifier"] == "worker:test"
+    assert document["status"] == "pending"
+
+
+def test_ingest_local_file_returns_existing_duplicate(db_path, tmp_data_dir):
+    from backend.ingestion.service import ingest_local_file
+
+    source = tmp_data_dir / "incoming.jpg"
+    _write_jpeg(source)
+
+    first = ingest_local_file(
+        str(source),
+        filename="first.jpg",
+        data_dir=str(tmp_data_dir),
+        submission_channel="web_upload",
+    )
+    second = ingest_local_file(
+        str(source),
+        filename="second.jpg",
+        data_dir=str(tmp_data_dir),
+        submission_channel="remote_intake",
+    )
+
+    assert first.status == "accepted"
+    assert second.status == "duplicate"
+    assert second.document_id == first.document_id
+    assert second.file_hash == first.file_hash
+    with get_connection() as conn:
+        count = conn.execute("SELECT COUNT(*) FROM documents").fetchone()[0]
+    assert count == 1

--- a/tests/test_remote_intake.py
+++ b/tests/test_remote_intake.py
@@ -1,0 +1,389 @@
+import asyncio
+import json
+import logging
+from urllib.parse import unquote
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import pytest
+from PIL import Image
+
+from backend.config import set_setting
+from backend.database import get_connection
+
+
+def _jpeg_bytes(tmp_path):
+    file_path = tmp_path / "receipt.jpg"
+    Image.new("RGB", (8, 8), color=(240, 240, 240)).save(file_path, "JPEG")
+    return file_path.read_bytes()
+
+
+def _enable_remote_intake(
+    *,
+    base_url="https://queue.example.test",
+    token="dedicated-test-token",
+    max_bytes=20 * 1024 * 1024,
+):
+    set_setting("remote_intake_enabled", True)
+    set_setting("remote_intake_base_url", base_url)
+    set_setting("remote_intake_token", token)
+    set_setting("remote_intake_batch_size", 10)
+    set_setting("remote_intake_max_file_bytes", max_bytes)
+
+
+@pytest.mark.asyncio
+async def test_disabled_remote_intake_makes_no_request(db_path, tmp_data_dir):
+    from backend.ingestion.remote_intake import poll_remote_intake_once
+
+    called = False
+
+    def handler(request):
+        nonlocal called
+        called = True
+        return httpx.Response(500)
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        assert (
+            await poll_remote_intake_once(data_dir=str(tmp_data_dir), client=client)
+            == 0
+        )
+    assert called is False
+
+
+@pytest.mark.asyncio
+async def test_incomplete_remote_intake_config_is_safe(
+    db_path, tmp_data_dir, caplog
+):
+    from backend.ingestion.remote_intake import poll_remote_intake_once
+
+    set_setting("remote_intake_enabled", True)
+    set_setting("remote_intake_base_url", "https://queue.example.test")
+    set_setting("remote_intake_token", "")
+    with caplog.at_level(logging.WARNING):
+        assert await poll_remote_intake_once(data_dir=str(tmp_data_dir)) == 0
+    assert "token" in caplog.text.lower()
+
+
+@pytest.mark.parametrize(
+    ("raw", "valid"),
+    [
+        ("https://queue.example.test", True),
+        ("https://queue.example.test/prefix/", True),
+        ("http://localhost:3000", True),
+        ("http://127.0.0.1:3000", True),
+        ("http://[::1]:3000", True),
+        ("http://queue.example.test", False),
+        ("https://queue.example.test/path?token=no", False),
+        ("https://queue.example.test/path#fragment", False),
+        ("https://user:pass@queue.example.test", False),
+    ],
+)
+def test_validate_remote_base_url(raw, valid):
+    from backend.ingestion.remote_intake import validate_remote_base_url
+
+    if valid:
+        assert validate_remote_base_url(raw).endswith(
+            raw.rstrip("/").split("://", 1)[1]
+        )
+    else:
+        with pytest.raises(ValueError):
+            validate_remote_base_url(raw)
+
+
+@pytest.mark.asyncio
+async def test_successful_remote_intake_cycle(db_path, tmp_data_dir):
+    from backend.ingestion.remote_intake import poll_remote_intake_once
+
+    _enable_remote_intake()
+    content = _jpeg_bytes(tmp_data_dir)
+    requests = []
+
+    def handler(request):
+        requests.append(request)
+        assert request.headers["Authorization"] == "Bearer dedicated-test-token"
+        if request.url.path == "/v1/receiptory/items":
+            assert request.url.params["limit"] == "10"
+            return httpx.Response(
+                200,
+                json={
+                    "items": [
+                        {
+                            "id": "worker/item 1",
+                            "filename": "receipt.jpg",
+                            "content_type": "image/jpeg",
+                            "sender_identifier": "private-worker-reference",
+                        }
+                    ]
+                },
+            )
+        if request.url.path.endswith("/content"):
+            assert unquote(request.url.path).endswith(
+                "/items/worker/item 1/content"
+            )
+            assert b"worker%2Fitem%201" in request.url.raw_path
+            return httpx.Response(
+                200, content=content, headers={"Content-Type": "image/jpeg"}
+            )
+        if request.url.path.endswith("/ack"):
+            return httpx.Response(200, json={"ok": True})
+        return httpx.Response(404)
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        acknowledged = await poll_remote_intake_once(
+            data_dir=str(tmp_data_dir), client=client
+        )
+
+    assert acknowledged == 1
+    ack = requests[-1]
+    assert ack.method == "POST"
+    payload = json.loads(ack.content)
+    assert payload["status"] == "accepted"
+    assert payload["document_id"] > 0
+    with get_connection() as conn:
+        document = conn.execute("SELECT * FROM documents").fetchone()
+    assert document["submission_channel"] == "remote_intake"
+    assert document["sender_identifier"] == "private-worker-reference"
+    assert document["status"] == "pending"
+
+
+@pytest.mark.asyncio
+async def test_lost_ack_redelivery_becomes_duplicate(db_path, tmp_data_dir):
+    from backend.ingestion.remote_intake import poll_remote_intake_once
+
+    _enable_remote_intake()
+    content = _jpeg_bytes(tmp_data_dir)
+    acknowledgements = []
+
+    def handler(request):
+        if request.url.path == "/v1/receiptory/items":
+            return httpx.Response(
+                200,
+                json={
+                    "items": [
+                        {
+                            "id": "stable-id",
+                            "filename": "receipt.jpg",
+                            "content_type": "image/jpeg",
+                        }
+                    ]
+                },
+            )
+        if request.url.path.endswith("/content"):
+            return httpx.Response(200, content=content)
+        if request.url.path.endswith("/ack"):
+            acknowledgements.append(json.loads(request.content))
+            if len(acknowledgements) == 1:
+                return httpx.Response(503)
+            return httpx.Response(200)
+        return httpx.Response(404)
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        assert (
+            await poll_remote_intake_once(data_dir=str(tmp_data_dir), client=client)
+            == 0
+        )
+        assert (
+            await poll_remote_intake_once(data_dir=str(tmp_data_dir), client=client)
+            == 1
+        )
+
+    assert acknowledgements[0]["status"] == "accepted"
+    assert acknowledgements[1]["status"] == "duplicate"
+    assert (
+        acknowledgements[0]["document_id"]
+        == acknowledgements[1]["document_id"]
+    )
+    with get_connection() as conn:
+        assert conn.execute("SELECT COUNT(*) FROM documents").fetchone()[0] == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("filename", "content_type", "body", "max_bytes", "detail"),
+    [
+        ("receipt.exe", "application/octet-stream", b"bad", 100, "unsupported"),
+        ("receipt.jpg", "image/jpeg", b"", 100, "empty"),
+        ("receipt.jpg", "image/jpeg", b"x" * 101, 100, "maximum"),
+        ("receipt.png", "image/jpeg", b"not-a-jpeg", 100, "extension"),
+        ("receipt.jpg", "image/jpeg", b"not-a-jpeg", 100, "content"),
+    ],
+)
+async def test_permanent_rejections_are_acknowledged(
+    db_path,
+    tmp_data_dir,
+    filename,
+    content_type,
+    body,
+    max_bytes,
+    detail,
+):
+    from backend.ingestion.remote_intake import poll_remote_intake_once
+
+    _enable_remote_intake(max_bytes=max_bytes)
+    ack_payload = None
+
+    def handler(request):
+        nonlocal ack_payload
+        if request.url.path == "/v1/receiptory/items":
+            return httpx.Response(
+                200,
+                json={
+                    "items": [
+                        {
+                            "id": "rejected",
+                            "filename": filename,
+                            "content_type": content_type,
+                        }
+                    ]
+                },
+            )
+        if request.url.path.endswith("/content"):
+            return httpx.Response(200, content=body)
+        if request.url.path.endswith("/ack"):
+            ack_payload = json.loads(request.content)
+            return httpx.Response(200)
+        return httpx.Response(404)
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        assert (
+            await poll_remote_intake_once(data_dir=str(tmp_data_dir), client=client)
+            == 1
+        )
+    assert ack_payload["status"] == "rejected"
+    assert detail in ack_payload["detail"].lower()
+    with get_connection() as conn:
+        assert conn.execute("SELECT COUNT(*) FROM documents").fetchone()[0] == 0
+
+
+@pytest.mark.asyncio
+async def test_malformed_list_is_not_acknowledged(db_path, tmp_data_dir):
+    from backend.ingestion.remote_intake import poll_remote_intake_once
+
+    _enable_remote_intake()
+
+    def handler(request):
+        return httpx.Response(200, json={"items": [{"id": 1}]})
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        assert (
+            await poll_remote_intake_once(data_dir=str(tmp_data_dir), client=client)
+            == 0
+        )
+
+
+@pytest.mark.asyncio
+async def test_auth_failure_and_logs_do_not_leak_secrets(
+    db_path, tmp_data_dir, caplog
+):
+    from backend.ingestion.remote_intake import (
+        RemoteIntakeAuthError,
+        poll_remote_intake_once,
+    )
+
+    _enable_remote_intake(token="never-log-this-token")
+    set_setting("remote_intake_base_url", "https://queue.example.test")
+
+    def handler(request):
+        return httpx.Response(401)
+
+    with caplog.at_level(logging.WARNING):
+        async with httpx.AsyncClient(
+            transport=httpx.MockTransport(handler)
+        ) as client:
+            with pytest.raises(RemoteIntakeAuthError):
+                await poll_remote_intake_once(
+                    data_dir=str(tmp_data_dir), client=client
+                )
+    assert "never-log-this-token" not in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_list_timeout_is_transient(db_path, tmp_data_dir):
+    from backend.ingestion.remote_intake import poll_remote_intake_once
+
+    _enable_remote_intake()
+
+    def handler(request):
+        raise httpx.ReadTimeout("timed out", request=request)
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        with pytest.raises(httpx.ReadTimeout):
+            await poll_remote_intake_once(
+                data_dir=str(tmp_data_dir), client=client
+            )
+
+
+def test_remote_intake_backoff_is_exponential_and_capped():
+    from backend.ingestion.remote_intake import _backoff_delay
+
+    assert _backoff_delay(1, 10, jitter=0) == 10
+    assert _backoff_delay(2, 10, jitter=0) == 20
+    assert _backoff_delay(10, 10, jitter=0) == 300
+    assert _backoff_delay(10, 10, jitter=1) == 300
+
+
+@pytest.mark.asyncio
+async def test_remote_intake_poller_backoff_resets_after_success(
+    db_path, tmp_data_dir
+):
+    from backend.ingestion.remote_intake import run_remote_intake_poller
+
+    timeout = httpx.ReadTimeout("temporary queue timeout")
+    side_effects = [timeout, timeout, 1, timeout, asyncio.CancelledError()]
+    with (
+        patch(
+            "backend.ingestion.remote_intake.poll_remote_intake_once",
+            new=AsyncMock(side_effect=side_effects),
+        ),
+        patch(
+            "backend.ingestion.remote_intake.asyncio.sleep",
+            new=AsyncMock(),
+        ) as sleep,
+        patch("backend.ingestion.remote_intake.random.uniform", return_value=0),
+    ):
+        with pytest.raises(asyncio.CancelledError):
+            await run_remote_intake_poller(str(tmp_data_dir))
+
+    assert [call.args[0] for call in sleep.await_args_list] == [10, 20, 10, 10]
+
+
+@pytest.mark.asyncio
+async def test_remote_intake_poller_cancellation_is_immediate(
+    db_path, tmp_data_dir
+):
+    from backend.ingestion.remote_intake import run_remote_intake_poller
+
+    with (
+        patch(
+            "backend.ingestion.remote_intake.poll_remote_intake_once",
+            new=AsyncMock(side_effect=asyncio.CancelledError()),
+        ),
+        patch(
+            "backend.ingestion.remote_intake.asyncio.sleep",
+            new=AsyncMock(),
+        ) as sleep,
+    ):
+        with pytest.raises(asyncio.CancelledError):
+            await run_remote_intake_poller(str(tmp_data_dir))
+    sleep.assert_not_awaited()
+
+
+def test_app_lifespan_starts_remote_intake_poller(db_path, tmp_data_dir):
+    from fastapi.testclient import TestClient
+    from backend.main import create_app
+
+    started = []
+
+    async def fake_remote_poller(data_dir):
+        started.append(data_dir)
+        await asyncio.Future()
+
+    with patch(
+        "backend.ingestion.remote_intake.run_remote_intake_poller",
+        new=fake_remote_poller,
+    ):
+        app = create_app(str(tmp_data_dir), run_background=True)
+        with TestClient(app):
+            pass
+
+    assert started == [str(tmp_data_dir)]

--- a/tests/test_remote_intake_e2e.py
+++ b/tests/test_remote_intake_e2e.py
@@ -1,0 +1,129 @@
+import json
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from time import monotonic, sleep
+from urllib.parse import urlsplit
+
+from fastapi.testclient import TestClient
+from PIL import Image
+
+from backend.config import set_setting
+from backend.database import get_connection
+from backend.main import create_app
+
+
+class _QueueState:
+    content = b""
+    token = ""
+    acknowledgements = []
+
+
+class _QueueHandler(BaseHTTPRequestHandler):
+    def _authorized(self):
+        return self.headers.get("Authorization") == f"Bearer {_QueueState.token}"
+
+    def _json(self, status, payload):
+        body = json.dumps(payload).encode()
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def do_GET(self):
+        if not self._authorized():
+            self._json(401, {"error": "unauthorized"})
+            return
+        path = urlsplit(self.path).path
+        if path == "/v1/receiptory/items":
+            self._json(
+                200,
+                {
+                    "items": [
+                        {
+                            "id": "e2e-item",
+                            "filename": "worker-receipt.jpg",
+                            "content_type": "image/jpeg",
+                            "sender_identifier": "private-e2e-worker",
+                        }
+                    ]
+                },
+            )
+            return
+        if path == "/v1/receiptory/items/e2e-item/content":
+            self.send_response(200)
+            self.send_header("Content-Type", "image/jpeg")
+            self.send_header("Content-Length", str(len(_QueueState.content)))
+            self.end_headers()
+            self.wfile.write(_QueueState.content)
+            return
+        self._json(404, {"error": "not found"})
+
+    def do_POST(self):
+        if not self._authorized():
+            self._json(401, {"error": "unauthorized"})
+            return
+        if urlsplit(self.path).path != "/v1/receiptory/items/e2e-item/ack":
+            self._json(404, {"error": "not found"})
+            return
+        length = int(self.headers.get("Content-Length", "0"))
+        _QueueState.acknowledgements.append(
+            json.loads(self.rfile.read(length).decode())
+        )
+        self._json(200, {"ok": True})
+
+    def log_message(self, format, *args):
+        pass
+
+
+def test_remote_queue_to_database_and_ack(db_path, tmp_data_dir):
+    image_path = tmp_data_dir / "queue-receipt.jpg"
+    Image.new("RGB", (8, 8), color=(220, 220, 220)).save(image_path, "JPEG")
+    _QueueState.content = image_path.read_bytes()
+    _QueueState.token = "private-e2e-token"
+    _QueueState.acknowledgements = []
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), _QueueHandler)
+    server_thread = threading.Thread(target=server.serve_forever, daemon=True)
+    server_thread.start()
+
+    set_setting("remote_intake_enabled", True)
+    set_setting(
+        "remote_intake_base_url",
+        f"http://127.0.0.1:{server.server_address[1]}",
+    )
+    set_setting("remote_intake_token", _QueueState.token)
+    set_setting("remote_intake_poll_interval_seconds", 1)
+
+    try:
+        app = create_app(str(tmp_data_dir), run_background=True)
+        with TestClient(app):
+            deadline = monotonic() + 5
+            while not _QueueState.acknowledgements and monotonic() < deadline:
+                sleep(0.05)
+            assert _QueueState.acknowledgements
+    finally:
+        server.shutdown()
+        server.server_close()
+        server_thread.join(timeout=2)
+
+    acknowledgement = _QueueState.acknowledgements[0]
+    assert acknowledgement["status"] == "accepted"
+    with get_connection() as conn:
+        document = conn.execute(
+            "SELECT * FROM documents WHERE id = ?",
+            (acknowledgement["document_id"],),
+        ).fetchone()
+    assert document["submission_channel"] == "remote_intake"
+    assert document["sender_identifier"] == "private-e2e-worker"
+    original = (
+        tmp_data_dir
+        / "storage"
+        / "originals"
+        / f"{document['file_hash']}.jpg"
+    )
+    assert original.read_bytes() == _QueueState.content
+
+    log_text = (tmp_data_dir / "logs" / "receiptory.log").read_text()
+    assert _QueueState.token not in log_text
+    assert "private-e2e-worker" not in log_text

--- a/tests/test_settings_api.py
+++ b/tests/test_settings_api.py
@@ -133,6 +133,20 @@ def test_env_overrides_requires_auth(app):
     assert resp.status_code == 401
 
 
+def test_remote_intake_token_override_is_reported_and_masked(
+    authed_client, monkeypatch
+):
+    monkeypatch.setenv(
+        "RECEIPTORY_REMOTE_INTAKE_TOKEN", "environment-worker-queue-secret"
+    )
+    overrides = authed_client.get("/api/settings/env-overrides")
+    assert "remote_intake_token" in overrides.json()["keys"]
+
+    settings = authed_client.get("/api/settings")
+    assert "environment-worker-queue-secret" not in settings.text
+    assert "***" in settings.json()["remote_intake_token"]
+
+
 def test_llm_api_keys_add_list_and_mask(authed_client):
     # DB-managed keys (#25): add returns name + last4 only, never the secret.
     resp = authed_client.post("/api/settings/llm-api-keys", json={"name": "OpenAI", "key": "sk-secret-123456"})

--- a/tests/test_telegram_files.py
+++ b/tests/test_telegram_files.py
@@ -1,0 +1,60 @@
+import os
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from backend.ingestion.service import IngestionResult
+
+
+def _telegram_file_context(tmp_data_dir, username="worker"):
+    update = MagicMock()
+    update.effective_user.id = 123
+    update.effective_user.username = username
+    update.message.reply_text = AsyncMock()
+
+    downloaded = MagicMock()
+    downloaded.download_to_drive = AsyncMock()
+    context = MagicMock()
+    context.bot_data = {"data_dir": str(tmp_data_dir)}
+    context.bot.get_file = AsyncMock(return_value=downloaded)
+    return update, context
+
+
+@pytest.mark.asyncio
+async def test_telegram_file_uses_shared_ingestion_service(db_path, tmp_data_dir):
+    from backend.ingestion.telegram import _ingest_file
+
+    update, context = _telegram_file_context(tmp_data_dir)
+    result = IngestionResult("accepted", 41, "abc123")
+
+    with patch(
+        "backend.ingestion.telegram.ingest_local_file", return_value=result
+    ) as ingest:
+        await _ingest_file(update, context, "telegram-file-id", "receipt.jpg")
+
+    call = ingest.call_args
+    assert call.kwargs["filename"] == "receipt.jpg"
+    assert call.kwargs["submission_channel"] == "telegram"
+    assert call.kwargs["sender_identifier"] == "telegram:@worker"
+    assert call.kwargs["data_dir"] == str(tmp_data_dir)
+    assert not os.path.exists(call.args[0])
+    update.message.reply_text.assert_awaited_once_with(
+        "Received! Document #41 queued for processing."
+    )
+
+
+@pytest.mark.asyncio
+async def test_telegram_file_reports_shared_service_duplicate(db_path, tmp_data_dir):
+    from backend.ingestion.telegram import _ingest_file
+
+    update, context = _telegram_file_context(tmp_data_dir, username=None)
+    result = IngestionResult("duplicate", 9, "abc123")
+
+    with patch(
+        "backend.ingestion.telegram.ingest_local_file", return_value=result
+    ):
+        await _ingest_file(update, context, "telegram-file-id", "receipt.pdf")
+
+    update.message.reply_text.assert_awaited_once_with(
+        "Duplicate file — already exists as document #9."
+    )

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -30,6 +30,11 @@ def test_upload_pdf(authed_client, sample_pdf_path):
     data = resp.json()
     assert len(data["documents"]) == 1
     assert data["documents"][0]["status"] == "pending"
+    with get_connection() as conn:
+        document = conn.execute(
+            "SELECT * FROM documents WHERE id = ?", (data["documents"][0]["id"],)
+        ).fetchone()
+    assert document["submission_channel"] == "web_upload"
 
 
 def test_upload_duplicate_rejected(authed_client, sample_pdf_path):


### PR DESCRIPTION
## Summary

- add an optional outbound-only receipt queue integration
- centralize browser, Telegram-file, and remote receipt ingestion behind one
  SHA-256-idempotent service
- add Remote Intake settings, environment configuration, and queue protocol
  documentation
- add unit and end-to-end coverage for delivery, acknowledgement, retries,
  duplicate handling, validation, and log redaction

## How it works

When enabled, Receiptory polls one configured queue origin, downloads pending
PDF or image content, stores it through the existing processing pipeline, and
acknowledges accepted, duplicate, or permanently rejected items. The Umbrel
host does not need a public port or inbound tunnel.

The integration is disabled by default. It requires HTTPS outside loopback,
uses a dedicated bearer token, percent-encodes item IDs, rejects item-provided
download URLs, streams files through a configurable size limit, validates
media types and file signatures, and omits tokens and sender identifiers from
logs.

## Verification

- `uv run pytest -q` — 336 passed, 1 skipped
- `npm run build --prefix frontend` — passed
- real FastAPI-lifespan E2E test covers queue listing, authenticated download,
  database/storage ingestion, and acknowledgement
- lost-ack retry coverage verifies content is acknowledged as a duplicate
  instead of creating a second document

The existing frontend lint backlog is unchanged by this feature.
