### PR TITLE
chore(claude-dev): Node 24 sidecar + Chromium deps + update docs

### DIFF
--- a/Dockerfile.claude
+++ b/Dockerfile.claude
@@ -7,7 +7,7 @@
 #
 # Build & run: see docs/claude-code-on-unraid.md or docker-compose.claude.yml.
 
-FROM node:20-bookworm
+FROM node:24-bookworm
 
 # Dev tools for the Claude Code CLI.
 # jq: required by gstack skills for JSONL task artifacts, review-log, and the

--- a/Dockerfile.claude
+++ b/Dockerfile.claude
@@ -47,6 +47,34 @@ RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
     && apt-get install -y --no-install-recommends gh \
     && rm -rf /var/lib/apt/lists/*
 
+# Chromium system libraries for gstack's browser skills (/browse, /qa,
+# /design-review). gstack's `./setup` downloads the Playwright Chromium binary
+# into $HOME/.cache (a persistent mount, so it survives rebuilds), but the
+# shared libs it links against live in the image layer and must be baked in
+# here — otherwise Chromium fails to launch with "libnspr4.so: cannot open
+# shared object file". This is Playwright's chromium dependency set for Debian
+# 12 (equivalent to `playwright install-deps chromium`).
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      libnss3 \
+      libnspr4 \
+      libatk1.0-0 \
+      libatk-bridge2.0-0 \
+      libatspi2.0-0 \
+      libcups2 \
+      libdbus-1-3 \
+      libdrm2 \
+      libgbm1 \
+      libxcomposite1 \
+      libxdamage1 \
+      libxfixes3 \
+      libxrandr2 \
+      libxkbcommon0 \
+      libasound2 \
+      libpango-1.0-0 \
+      libcairo2 \
+      fonts-liberation \
+    && rm -rf /var/lib/apt/lists/*
+
 # claude-code CLI + bun. bun is the JS runtime several gstack skill scripts
 # shell out to (e.g. gstack-review-log validates JSON via `bun -e`, gstack-
 # learnings-log runs under bun); without it those writes silently no-op.

--- a/docs/claude-code-on-unraid.md
+++ b/docs/claude-code-on-unraid.md
@@ -108,7 +108,7 @@ docker exec claude-dev npm install -g @anthropic-ai/claude-code@latest
 
 ### Updating Node
 
-Node's version is pinned by the **base image tag** on line 1 of `Dockerfile.claude`:
+Node's version is pinned by the **base image tag** on the `FROM` line of `Dockerfile.claude`:
 
 ```dockerfile
 FROM node:24-bookworm

--- a/docs/claude-code-on-unraid.md
+++ b/docs/claude-code-on-unraid.md
@@ -15,7 +15,7 @@ the same for Claude Code.
 
 ## What's here
 
-- **`Dockerfile.claude`** — a lightweight `node:20` image with the Claude Code CLI,
+- **`Dockerfile.claude`** — a lightweight `node:24` image with the Claude Code CLI,
   `git`, `ripgrep`, and the Docker *client* + Compose v2 plugin (client-only, no
   daemon; drives the host daemon via the mounted socket).
 - **`docker-compose.claude.yml`** — runs that image as a `claude-dev` container,
@@ -68,6 +68,62 @@ This reuses the app's real image build (backend + frontend), so the dev containe
 doesn't need Python/uv/npm. For tighter loops (running `pytest`, hot reload) you
 can instead install `uv` and the frontend deps into the dev container and run the
 dev servers per the root `CLAUDE.md`.
+
+## Updating Claude Code and Node
+
+Both the Claude Code CLI and Node live **inside the `claude-dev` image**, not on the
+host. Because the container's `/usr/local` is an image layer (not a mounted volume),
+anything you `npm install -g` or unpack there by hand survives container *restarts*
+but is **wiped whenever the sidecar is recreated from its image** (`--build`,
+`docker rm`, or an UNRAID container update). So the durable fix always lives in
+`Dockerfile.claude`, and applying it means rebuilding the sidecar.
+
+### Updating Claude Code
+
+The CLI is installed by this line in `Dockerfile.claude`:
+
+```dockerfile
+RUN npm install -g @anthropic-ai/claude-code bun
+```
+
+`npm install -g` already pulls the **latest** published version at build time, so the
+durable way to update Claude Code is simply to rebuild the sidecar (this re-runs the
+`npm install -g` layer against the current npm registry):
+
+```bash
+# from the repo dir on the NAS
+docker compose -f docker-compose.claude.yml build --no-cache claude-dev
+docker compose -f docker-compose.claude.yml up -d
+```
+
+`--no-cache` forces the `npm install -g` layer to re-run; without it Docker may reuse
+a cached layer and keep the old version. To pin a specific version instead of latest,
+change the line to `@anthropic-ai/claude-code@<version>` before rebuilding.
+
+For a **quick, non-durable** bump inside the running container (lost on next rebuild):
+
+```bash
+docker exec claude-dev npm install -g @anthropic-ai/claude-code@latest
+```
+
+### Updating Node
+
+Node's version is pinned by the **base image tag** on line 1 of `Dockerfile.claude`:
+
+```dockerfile
+FROM node:24-bookworm
+```
+
+To move to a new major (e.g. Node 26 LTS when it lands), change the tag and rebuild
+the sidecar with the same two commands as above. Keep it at or above the minimum the
+Claude Code CLI requires (currently `node >=22`); `node:<major>-bookworm` always
+resolves to the latest patch of that line at build time.
+
+> **Heads-up: the rebuild recreates the container you're working in.** If you run the
+> rebuild *from inside* a `claude-dev` session, it will terminate that session when the
+> container is replaced. Run it from the UNRAID host (or the container's `>_` console),
+> then `docker exec -it claude-dev claude` back in. Verify afterward with
+> `docker exec claude-dev sh -c 'node --version && claude --version'`.
 
 ## Notes & cautions
 


### PR DESCRIPTION
## What

Makes the `claude-dev` dev sidecar durable and self-documenting. Three related changes, all scoped to the dev container (no application code):

1. **Node 20 → 24** (`Dockerfile.claude` base image). Claude Code now requires `node >=22`; the sidecar was on `node:20-bookworm`, which emitted an `EBADENGINE` warning and would eventually block CLI installs.
2. **Chromium system libraries baked in.** gstack's browser skills (`/browse`, `/qa`, `/design-review`) need Chromium. gstack's `./setup` downloads the Chromium binary into `$HOME/.cache` (a persistent mount), but the shared libs it links against live in the image layer. Without them Chromium fails to launch (`libnspr4.so: cannot open shared object file`). Added Playwright's Debian-12 chromium dependency set.
3. **Docs:** new "Updating Claude Code and Node" section in `docs/claude-code-on-unraid.md` explaining why in-place `/usr/local` updates are ephemeral (image layer, not a volume) and giving the durable rebuild recipe, with a heads-up that the rebuild recreates the session's own container.

## Why it matters

Everything the sidecar installs into `/usr/local` (Node, Claude Code) is wiped when the container is recreated from its image. The durable fixes have to live in `Dockerfile.claude`. This PR moves the Node bump and the Chromium deps there so they survive UNRAID container updates and `--build` rebuilds.

## Testing

No application code changed — the diff is `Dockerfile.claude` (dev sidecar) + `docs/*.md` only. The pytest suite exercises none of these files, so it was not run. The running container was already validated live this session: Node 24 + Claude Code + bun all work, and Chromium launches after the dep install (verified `ldd` clean + headless launch exit 0).

## Deploy note

Takes effect on the **next sidecar rebuild**, which must be run from the UNRAID host (not inside a `claude-dev` session — it recreates the container you're in):

```bash
docker compose -f docker-compose.claude.yml build --no-cache claude-dev
docker compose -f docker-compose.claude.yml up -d
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)