### PR TITLE
fix(ingestion): capture real PDF for button-gated & SPA bill viewers (#32)

### DIFF
--- a/backend/ingestion/gmail.py
+++ b/backend/ingestion/gmail.py
@@ -12,7 +12,7 @@ from bs4 import BeautifulSoup as _BS
 
 from backend.config import get_setting
 from backend.database import get_connection
-from backend.ingestion.url_fetcher import fetch_url
+from backend.ingestion.url_fetcher import fetch_url, PAGE_CAPTURE_NOTE
 from backend.storage import compute_file_hash, save_original
 
 logger = logging.getLogger(__name__)
@@ -338,7 +338,7 @@ def _ingest_url(url: str, sender_email: str, data_dir: str, authorized: bool, fe
 
         category_id = None
         status = "pending" if authorized else "needs_review"
-        if fetch_result.auth_wall:
+        if fetch_result.auth_wall or fetch_result.page_capture:
             status = "needs_review"
         if not authorized:
             with get_connection() as conn:
@@ -351,6 +351,8 @@ def _ingest_url(url: str, sender_email: str, data_dir: str, authorized: bool, fe
         user_notes = None
         if fetch_result.auth_wall:
             user_notes = f"Auth-gated URL: {url}"
+        elif fetch_result.page_capture:
+            user_notes = PAGE_CAPTURE_NOTE.format(url=url)
 
         filename = os.path.basename(fetch_result.file_path)
         with get_connection() as conn:

--- a/backend/ingestion/telegram.py
+++ b/backend/ingestion/telegram.py
@@ -16,7 +16,7 @@ from backend.config import get_setting
 from backend.database import get_connection
 from backend.storage import compute_file_hash, save_original
 from backend.ingestion.url_triage import triage_telegram_urls
-from backend.ingestion.url_fetcher import fetch_url
+from backend.ingestion.url_fetcher import fetch_url, PAGE_CAPTURE_NOTE
 
 logger = logging.getLogger(__name__)
 
@@ -121,10 +121,15 @@ async def handle_text(update: Update, context: ContextTypes.DEFAULT_TYPE) -> Non
 
             save_original(result.file_path, file_hash, ext, data_dir)
 
-            # Determine status based on auth wall
+            # Determine status. Auth walls AND viewer-shell page captures both
+            # route to needs_review — a page.pdf() render is not the real file
+            # (issue #32); filing it as pending would hide the capture failure.
             if result.auth_wall:
                 status = "needs_review"
                 user_notes = f"Auth-gated URL: {url} — login required, page capture saved."
+            elif result.page_capture:
+                status = "needs_review"
+                user_notes = PAGE_CAPTURE_NOTE.format(url=url)
             else:
                 status = "pending"
                 user_notes = None

--- a/backend/ingestion/url_fetcher.py
+++ b/backend/ingestion/url_fetcher.py
@@ -15,7 +15,7 @@ import uuid
 from dataclasses import dataclass, field
 from ipaddress import ip_address, ip_network
 from pathlib import Path
-from urllib.parse import urljoin, urlparse
+from urllib.parse import unquote, urljoin, urlparse
 
 import httpx
 from bs4 import BeautifulSoup
@@ -64,8 +64,32 @@ def _is_safe_url(url: str) -> bool:
 # File extensions considered downloadable documents
 DOCUMENT_EXTENSIONS = (".pdf", ".png", ".jpg", ".jpeg", ".tiff")
 
-# Keywords in URL or link text that indicate a download link
+# Keywords in URL or link text that indicate a download link. Kept narrow and
+# English-only ON PURPOSE: this drives _find_document_links, which follows <a>
+# links in the static httpx scan; broadening it there causes false-positive
+# link-follows (issue #32 eng-review, finding 3). The button-click path (issue
+# #32) uses the separate, broader _CLICK_DOWNLOAD_KEYWORDS below.
 DOWNLOAD_KEYWORDS = re.compile(r"download|invoice|receipt", re.IGNORECASE)
+
+# Broader multilingual net for the Playwright button-click download path only
+# (issue #32). Matched against a control's visible text, aria-label, title,
+# value, and download attribute. Hebrew is first-class: receipt portals like
+# mast.co.il label the download control "הורדה".
+_CLICK_DOWNLOAD_KEYWORDS = re.compile(
+    r"download|\bpdf\b|invoice|receipt|save|"
+    r"הורדה|הורד|להורדה|הורדת|חשבונית|קבלה",
+    re.IGNORECASE,
+)
+
+# Controls we must NEVER click, even if they also match a download keyword —
+# these are destructive or money-moving actions on the user's billing account
+# (issue #32, finding 1: guarded single-click). Checked against the same
+# text/attrs as the keyword net; a match here disqualifies the candidate.
+_CLICK_DENYLIST = re.compile(
+    r"\bpay\b|payment|checkout|\bdelete\b|remove|submit|"
+    r"שלם|תשלום|לתשלום|מחק|הסר|שלח",
+    re.IGNORECASE,
+)
 
 # Map content-type prefixes to file extensions
 CONTENT_TYPE_EXT = {
@@ -83,7 +107,10 @@ class FetchResult:
     content_type: str  # MIME type
     original_url: str  # Source URL
     auth_wall: bool = False  # True if login page detected
-    method: str = ""  # "direct", "link_follow", "playwright_download", "playwright_network", "playwright_capture"
+    # True when the file is a page.pdf() render of the viewer shell, not a real
+    # downloaded document — callers route these to needs_review (issue #32).
+    page_capture: bool = False
+    method: str = ""  # "direct", "link_follow", "mast_api", "playwright_download", "playwright_download_click", "playwright_network", "playwright_capture"
 
 
 def _ext_for_content_type(content_type: str) -> str:
@@ -105,6 +132,20 @@ def _is_document_content_type(content_type: str) -> bool:
 def _is_html_content_type(content_type: str) -> bool:
     ct = content_type.split(";")[0].strip().lower()
     return "html" in ct
+
+
+def _content_type_for_ext(ext: str) -> str:
+    """Map a file extension back to a content-type (reverse of CONTENT_TYPE_EXT),
+    single-sourced so it can't drift from CONTENT_TYPE_EXT."""
+    for ct, e in CONTENT_TYPE_EXT.items():
+        if e == ext:
+            return ct
+    return "application/pdf"
+
+
+# Shared needs_review note for a viewer-shell page.pdf() capture (issue #32),
+# used by both the gmail and telegram callers so the wording can't drift.
+PAGE_CAPTURE_NOTE = "Captured the viewer page render, not a downloaded file — verify the PDF: {url}"
 
 
 def _save_response(content: bytes, content_type: str, download_dir: str) -> str:
@@ -177,6 +218,10 @@ _DOC_STREAM_DETECT = 5
 # arbitrarily large application/pdf and OOM the single-process NAS deployment.
 _MAX_CAPTURE_BYTES = 50 * 1024 * 1024
 
+# Cap on retained application/pdf responses (the listener lives for the whole
+# page lifetime on the issue #32 dual-capture path).
+_MAX_PDF_RESPONSES = 20
+
 
 async def _read_streamed_pdf(page, pdf_responses: list) -> bytes | None:
     """Wait (bounded) for a canvas viewer to stream a PDF, return its bytes.
@@ -221,6 +266,153 @@ async def _read_streamed_pdf(page, pdf_responses: list) -> bytes | None:
     return None
 
 
+# Seconds to wait for a button-triggered download event (or an inline PDF
+# response) after clicking a download control. Longer than the load-time detect
+# window (a build-on-click PDF can take a few seconds) but bounded so the
+# single-process queue can't hang. Applies ONLY after a matched control is
+# clicked, so button-less pages never pay this wait.
+_DOC_CLICK_TIMEOUT = 15
+
+
+def _matches_click_download(text: str) -> bool:
+    """True if a control's text/attrs look like a download control AND are not
+    a denylisted (money-moving / destructive) action."""
+    if not text:
+        return False
+    if _CLICK_DENYLIST.search(text):
+        return False
+    return bool(_CLICK_DOWNLOAD_KEYWORDS.search(text))
+
+
+async def _candidate_label(el) -> str:
+    """Concatenate a control's visible text and download-ish attributes."""
+    parts = []
+    try:
+        parts.append(await el.inner_text())
+    except Exception:
+        pass
+    for attr in ("aria-label", "title", "value", "download"):
+        try:
+            v = await el.get_attribute(attr)
+            if v:
+                parts.append(v)
+        except Exception:
+            pass
+    return " ".join(p for p in parts if p)
+
+
+def _save_capture_bytes(content: bytes, download_dir: str, suggested: str | None) -> str | None:
+    """Save downloaded bytes to a temp file, enforcing the size cap. Returns the
+    path, or None if empty / over the cap."""
+    if not content or len(content) > _MAX_CAPTURE_BYTES:
+        return None
+    ext = Path(suggested or "").suffix.lower()
+    if ext not in DOCUMENT_EXTENSIONS:
+        ext = ".pdf"
+    file_path = str(Path(download_dir) / f"{uuid.uuid4().hex}{ext}")
+    Path(file_path).write_bytes(content)
+    return file_path
+
+
+# Controls whose label most strongly signals a document download (ranked first).
+_STRONG_CLICK_KEYWORDS = re.compile(r"download|\bpdf\b|הורדה|הורד|להורדה|הורדת", re.IGNORECASE)
+
+
+async def _try_click_download(page, download_dir: str, pdf_responses: list) -> FetchResult | None:
+    """Issue #32: click the single best download control and capture the PDF.
+
+    Dual capture — a client-side SPA may deliver the file either as a browser
+    download event (attachment) OR as an inline application/pdf response. The
+    page's response listener stays alive (pdf_responses), and the click is
+    wrapped in expect_download; whichever fires wins. A mis-click that produces
+    neither returns None, so the caller falls back to page.pdf() (needs_review)
+    — expect_download is the safety property: no fake success can be filed.
+    """
+    from playwright.async_api import TimeoutError as PlaywrightTimeoutError
+
+    try:
+        elements = await page.query_selector_all("button, [role=button], a")
+    except Exception:
+        return None
+
+    ranked: list = []
+    for el in elements:
+        try:
+            if not await el.is_visible() or not await el.is_enabled():
+                continue
+        except Exception:
+            continue
+        label = await _candidate_label(el)
+        if not _matches_click_download(label):
+            continue
+        rank = 0 if _STRONG_CLICK_KEYWORDS.search(label) else 1
+        ranked.append((rank, el))
+
+    if not ranked:
+        return None
+    ranked.sort(key=lambda t: t[0])
+    best = ranked[0][1]
+    page_url = getattr(page, "url", "")
+
+    # Click the single best candidate; capture a download event if one fires.
+    download = None
+    try:
+        async with page.expect_download(timeout=_DOC_CLICK_TIMEOUT * 1000) as dl_info:
+            await best.click()
+        download = await dl_info.value
+    except PlaywrightTimeoutError:
+        download = None  # no download event — try the inline-response path below
+    except Exception as exc:
+        logger.debug("Click-download attempt failed for %s: %s", page_url, exc)
+        download = None
+
+    if download is not None:
+        try:
+            dl_url = download.url or ""
+            scheme = urlparse(dl_url).scheme.lower()
+            # Re-gate real http(s) download URLs (SSRF). blob:/data: are
+            # browser-created — gate them on the page's own origin instead (a
+            # safe page could still have fetched internal bytes into a blob).
+            if scheme in ("http", "https"):
+                if not _is_safe_url(dl_url):
+                    logger.warning("Skipping click-download from unsafe host: %s", urlparse(dl_url).hostname)
+                    return None
+            elif page_url.startswith(("http://", "https://")) and not _is_safe_url(page_url):
+                logger.warning("Skipping blob/data click-download from unsafe page origin")
+                return None
+            # expect_download resolves when the download STARTS; download.path()
+            # blocks until it COMPLETES. Bound it — a stalled body would otherwise
+            # hang the single-process ingestion queue indefinitely.
+            path_str = await asyncio.wait_for(download.path(), timeout=_DOC_CLICK_TIMEOUT)
+            # Size-cap on disk BEFORE loading into memory: Playwright streams the
+            # download with no limit, so read_bytes() on a huge file would OOM.
+            if path_str and Path(path_str).stat().st_size <= _MAX_CAPTURE_BYTES:
+                data = Path(path_str).read_bytes()
+                saved = _save_capture_bytes(data, download_dir, download.suggested_filename)
+                if saved:
+                    return FetchResult(
+                        file_path=saved,
+                        content_type=_content_type_for_ext(Path(saved).suffix.lower()),
+                        original_url=page_url,
+                        method="playwright_download_click",
+                    )
+        except Exception as exc:
+            logger.debug("Failed saving click-download for %s: %s", page_url, exc)
+
+    # No usable download event — the click may have streamed an inline PDF.
+    inline = await _read_streamed_pdf(page, pdf_responses)
+    if inline:
+        saved = _save_capture_bytes(inline, download_dir, "document.pdf")
+        if saved:
+            return FetchResult(
+                file_path=saved,
+                content_type="application/pdf",
+                original_url=page_url,
+                method="playwright_download_click",
+            )
+    return None
+
+
 async def _playwright_fetch(
     url: str, download_dir: str, timeout: int, user_agent: str | None = None,
 ) -> FetchResult | None:
@@ -259,7 +451,11 @@ async def _playwright_fetch(
             if clen.isdigit() and int(clen) > _MAX_CAPTURE_BYTES:
                 logger.warning("Skipping oversized captured PDF (%s bytes): %s", clen, resp.url)
                 return
-            pdf_responses.append(resp)
+            # Bound growth: the listener stays attached for the whole page
+            # lifetime (issue #32 dual capture), so cap retained responses so a
+            # page emitting many PDF responses can't grow the list unboundedly.
+            if len(pdf_responses) < _MAX_PDF_RESPONSES:
+                pdf_responses.append(resp)
         except Exception:
             pass
 
@@ -284,7 +480,9 @@ async def _playwright_fetch(
                 # Give a canvas-based viewer a bounded window to stream its
                 # document, then save the first readable PDF response.
                 streamed_pdf = await _read_streamed_pdf(page, pdf_responses)
-                page.remove_listener("response", _on_response)
+                # NOTE: the response listener stays attached past here so the
+                # button-click path (issue #32) can still catch an inline PDF
+                # response the click triggers. It is torn down with the page.
                 if streamed_pdf:
                     file_path = _save_response(
                         streamed_pdf, "application/pdf", download_dir
@@ -336,7 +534,17 @@ async def _playwright_fetch(
                             result.method = "playwright_download"
                             return result
 
-                # Fallback: capture the page as PDF
+                # Issue #32: the real PDF may sit behind a JS download button
+                # (no <a href>, no load-time stream) — e.g. mast.co.il/bill-viewer.
+                # Click the best download control and capture what it produces.
+                click_result = await _try_click_download(page, download_dir, pdf_responses)
+                if click_result is not None:
+                    return click_result
+
+                # Fallback: capture the page as PDF. This is a render of the
+                # viewer SHELL, not a real document — flag page_capture so the
+                # caller routes it to needs_review instead of filing it as the
+                # real bill (issue #32).
                 pdf_bytes = await page.pdf()
                 file_path = _save_response(
                     pdf_bytes, "application/pdf", download_dir
@@ -346,11 +554,119 @@ async def _playwright_fetch(
                     content_type="application/pdf",
                     original_url=url,
                     method="playwright_capture",
+                    page_capture=True,
                 )
             finally:
                 await browser.close()
     except Exception as exc:
         logger.error("Playwright fetch failed for %s: %s", url, exc)
+        return None
+
+
+# --- Site handler: mast.co.il municipal bill viewer (issue #32) ---------------
+# The mast bill-viewer is an Angular SPA (shadow DOM + iframes + invisible
+# reCAPTCHA v3) that renders nothing capturable and hides the download behind a
+# JS flow — the generic browser path only ever captures the viewer shell. But
+# the SPA fetches the bill from a public JSON API keyed by the SAME guid that is
+# in the viewer URL, and that JSON carries a direct `pdfLink`. So we skip the
+# browser entirely and fetch the real PDF deterministically over httpx.
+_MAST_API = "https://api.mast.co.il/mast/api/Stubs/GetStubsByGuidForPresentingStubs"
+_MAST_API_TIMEOUT = 15   # floor for the JSON API GET
+_MAST_PDF_TIMEOUT = 30   # floor for the Azure-blob PDF GET
+
+
+def _mast_guid(url: str) -> str | None:
+    """Return the decoded bill guid if `url` is a mast.co.il bill-viewer link."""
+    parsed = urlparse(url)
+    host = (parsed.hostname or "").lower()
+    if host not in ("mast.co.il", "www.mast.co.il"):
+        return None
+    parts = [p for p in parsed.path.split("/") if p]
+    if len(parts) >= 2 and parts[0] == "bill-viewer":
+        return unquote(parts[1])  # path segment is percent-encoded
+    return None
+
+
+async def _fetch_mast_bill(url: str, download_dir: str, timeout: int) -> FetchResult | None:
+    """Resolve a mast bill-viewer URL to its real PDF via the mast JSON API.
+
+    Returns None on any failure so the caller falls through to the generic
+    fetch path (which ends at page.pdf() -> page_capture -> needs_review).
+    """
+    guid = _mast_guid(url)
+    if not guid:
+        return None
+    headers = {
+        "User-Agent": _DESKTOP_USER_AGENT,
+        "Accept": "application/json",
+        "Origin": "https://www.mast.co.il",
+        "Referer": "https://www.mast.co.il/",
+    }
+    # follow_redirects=False: _is_safe_url gates only the initial host, and httpx
+    # does NOT re-run it on redirect hops, so a 3xx to an internal host would
+    # bypass the SSRF check. The mast API + Azure blob are direct URLs; a redirect
+    # is unexpected and safer to refuse. The parse loop is INSIDE the try so any
+    # unexpected-but-valid JSON shape (array/string) degrades to None instead of
+    # raising AttributeError up through the unguarded gmail caller (issue #32).
+    try:
+        async with httpx.AsyncClient(headers=headers) as client:
+            resp = await client.get(
+                _MAST_API, params={"guid": guid},
+                timeout=max(int(timeout), _MAST_API_TIMEOUT), follow_redirects=False,
+            )
+        if resp.status_code >= 400:
+            logger.warning("mast API HTTP %d", resp.status_code)
+            return None
+        if len(resp.content) > _MAX_CAPTURE_BYTES:
+            logger.warning("mast API body too large (%d bytes)", len(resp.content))
+            return None
+        data = resp.json()
+        if not isinstance(data, dict):
+            logger.warning("mast API returned unexpected JSON shape")
+            return None
+        # Collect candidate PDF links across all stubs for this period. A period
+        # can carry more than one stub; we return one file per URL, so take the
+        # first usable link and log if others were dropped.
+        links: list[str] = []
+        for stub in (data.get("stubExtentionList") or []):
+            if not isinstance(stub, dict):
+                continue
+            for key in ("pdfLink", "fileUrlAttachment", "attachmentFileUrl"):
+                val = stub.get(key)
+                if val and isinstance(val, str) and val.startswith(("http://", "https://")):
+                    links.append(val)
+    except (httpx.HTTPError, ValueError, TypeError) as exc:
+        logger.warning("mast API fetch/parse failed: %s", exc)
+        return None
+
+    if not links:
+        logger.warning("mast API returned no pdfLink")
+        return None
+    if len(links) > 1:
+        logger.info("mast bill has %d stub PDFs; ingesting the first", len(links))
+
+    pdf_url = links[0]
+    if not _is_safe_url(pdf_url):
+        # Log host only — the pdfLink carries an Azure SAS token in its query.
+        logger.warning("mast pdfLink points to unsafe host: %s", urlparse(pdf_url).hostname)
+        return None
+    try:
+        async with httpx.AsyncClient(headers={"User-Agent": _DESKTOP_USER_AGENT}) as client:
+            pr = await client.get(
+                pdf_url, timeout=max(int(timeout), _MAST_PDF_TIMEOUT), follow_redirects=False,
+            )
+        if pr.status_code >= 400 or len(pr.content) > _MAX_CAPTURE_BYTES:
+            return None
+        ct = pr.headers.get("content-type", "application/pdf")
+        file_path = _save_response(pr.content, ct, download_dir)
+        return FetchResult(
+            file_path=file_path,
+            content_type=ct.split(";")[0].strip(),
+            original_url=url,
+            method="mast_api",
+        )
+    except httpx.HTTPError as exc:
+        logger.warning("mast pdfLink fetch failed: %s", exc)
         return None
 
 
@@ -369,6 +685,14 @@ async def fetch_url(
     if not _is_safe_url(url):
         logger.warning("Blocked unsafe URL (private/internal network): %s", url)
         return None
+
+    # Site handler: mast.co.il bill viewer resolves to its real PDF via the mast
+    # JSON API (issue #32). Tried first; falls through to the generic path on any
+    # failure so a mast API change can't strand ingestion.
+    if _mast_guid(url):
+        mast_result = await _fetch_mast_bill(url, download_dir, timeout)
+        if mast_result is not None:
+            return mast_result
 
     # Step 1: HTTP fetch (mobile UA — many receipt links expect mobile browser)
     ua = user_agent or _MOBILE_USER_AGENT

--- a/docs/plans/2026-09-02-issue32-email-button-download.md
+++ b/docs/plans/2026-09-02-issue32-email-button-download.md
@@ -1,0 +1,346 @@
+# Issue #32 — Email bills behind a JS download button capture the viewer shell, not the PDF
+
+Branch: `fix/issue32-email-button-download`
+Issue: https://github.com/LevMuchnik/Receiptory/issues/32
+Related: #27 (Adobe canvas-viewer streamed-PDF capture — same function)
+
+## Problem
+
+Email-ingested bills from `mast.co.il/bill-viewer/<token>` (מועצה מקומית מבשרת ציון,
+sender `mast@outbox.co.il`) store a **1-page render of the viewer web page** instead
+of the real multi-page PDF. The doc still extracts at 0.95 and is marked `processed`,
+so the failure is **silent**. Evidence: doc 266 (email) = 1 page / 309 KB; doc 185
+(real PDF, hand-submitted) = 2 pages / 680 KB.
+
+## Root cause (confirmed — see issue #32)
+
+`fetch_url` → `_playwright_fetch` (`backend/ingestion/url_fetcher.py`) resolves a viewer
+URL through three shapes, and the mast Angular SPA matches none:
+
+```
+_playwright_fetch(url)
+  goto(load)
+  ├─ (1) application/pdf streamed on load?  ── #27 path (_read_streamed_pdf) ──▶ save real PDF
+  │        mast: NO stream on load (PDF built only on button click)          ✗
+  ├─ (2) password field? ─▶ page.pdf() auth_wall capture
+  ├─ (3) <a href> doc link in rendered DOM? (_find_document_links)
+  │        - scans <a> ONLY (mast control is a <button>)                     ✗
+  │        - DOWNLOAD_KEYWORDS = /download|invoice|receipt/i  (English only;
+  │          mast button text is Hebrew "הורדה")                             ✗
+  └─ (4) FALLBACK: page.pdf() ──▶ renders the VIEWER SHELL (1 page)  ◀── lands here, filed as the bill
+```
+
+Two defects compound: (a) no button-triggered-download handling exists at all
+(`page.expect_download()` appears nowhere), and (b) the `page.pdf()` fallback produces
+a plausible artifact that extracts cleanly, so a capture failure is filed as `processed`.
+
+## Goals
+
+1. Capture the real PDF when it sits behind a JS download button/link (mast and the
+   general class of button-gated Hebrew/English receipt portals).
+2. Stop the silent-success masking: when we fall back to a `page.pdf()` viewer-shell
+   capture, route the document to `needs_review` instead of `pending`/`processed`.
+
+## Design
+
+### Change 1 — button-triggered download in `_playwright_fetch`
+
+Insert a new capture attempt **between the DOM `<a href>` scan (step 3) and the
+`page.pdf()` fallback (step 4)**. Order matters: the streamed-PDF path (#27) and the
+existing `<a href>` follow stay ahead of it (they are cheaper and already proven); the
+button click is the new last resort before giving up to `page.pdf()`.
+
+```
+(3) <a href> doc-link follow           (unchanged)
+(3b) NEW: click a download control inside page.expect_download()
+        - locate candidate controls: <button>, [role=button], <a>, elements whose
+          visible text / aria-label / title / value / download attr matches a
+          multilingual DOWNLOAD keyword net
+        - for the first candidate: async with page.expect_download() as dl_info:
+              await candidate.click()
+          save download.path() -> temp file; SSRF re-check download.url; size cap
+        - method="playwright_download_click"
+(4) page.pdf() fallback                (now flagged — see Change 2)
+```
+
+Details:
+- **Two keyword nets (eng-review decision, finding 3 → scoped, NOT shared).** Do NOT
+  broaden the existing `DOWNLOAD_KEYWORDS`: it is used by `_find_document_links` in the
+  static httpx `<a>`-scan (`fetch_url:407`), and broadening it there raises false-positive
+  link-follows. Instead add a SEPARATE `_CLICK_DOWNLOAD_KEYWORDS` net for step 3b only:
+  Hebrew `הורדה`/`הורד`/`להורדה`/`הורדת` + English `download`/`pdf`/`save`, matched against
+  the control's visible text AND `aria-label`/`title`/`value`/`download` attr. The static
+  scan keeps its conservative English-link net unchanged.
+- **Locating controls.** Use Playwright locators, not BeautifulSoup — the download is a
+  live DOM element with JS handlers. Query `button, [role=button], a[href]`
+  (drop `input[type=submit]` — outside voice #8: it contradicts the pay/submit denylist
+  and is not a download affordance), filter by `_CLICK_DOWNLOAD_KEYWORDS` against
+  text/attrs, take visible+enabled ones.
+- **Ranking + denylist (eng-review decision, finding 1 → guarded single-click).** Rank
+  candidates: download/PDF keywords (`הורדה`/`download`/`pdf`) above print/save; and a
+  hard **never-click denylist** — skip any control matching pay/submit/checkout/delete
+  and their Hebrew equivalents (`שלם`/`תשלום`/`מחק`). These are billing portals; a wrong
+  click could trigger a real account action.
+- **Dual capture after the click (eng-review decision, finding 1+2 → dual capture).**
+  A client-side SPA can deliver the PDF two ways when the button is clicked: as a browser
+  **download event** (attachment) OR as an **inline `application/pdf` response**. Cover
+  both — do NOT remove the `_on_response` listener before clicking:
+  - Keep the `_on_response` PDF listener (line 245) ALIVE across the click.
+  - `async with page.expect_download(timeout=...)`: click the **single best** candidate,
+    then take `download.path()` if the event fired.
+  - After the click, ALSO re-check `pdf_responses` via `_read_streamed_pdf` — if the PDF
+    came back as an inline response, capture it there.
+  - Take whichever fired. If neither, fall through to `page.pdf()`.
+  `expect_download` is the safety property: a mis-click that produces no download/response
+  can never be filed as a fake success (it lands in the `page.pdf()` → needs_review path).
+- **SSRF re-check allows blob:/data: (eng-review decision, finding 1).** `_is_safe_url`
+  (url_fetcher.py:48) returns False for any non-http(s) scheme, so a client-generated
+  `blob:`/`data:` download URL would be wrongly rejected — silently defeating the fix for
+  the most likely mast case. Apply `_is_safe_url` ONLY to `http`/`https` download URLs;
+  ALLOW `blob:`/`data:` (same-origin, browser-created; the top-level page already passed
+  `_is_safe_url` at navigation). The inline-response path keeps its existing per-response
+  `_is_safe_url` gate (those are real http(s) URLs).
+- **Bounded wait.** Bound the click/download wait with a **~15s window** (not 5s — a
+  build-on-click PDF can take longer; #27's settle is 10s; not the 30s nav floor). This
+  wait applies ONLY after a matched download control is clicked, so button-less viewer
+  pages skip it entirely and are not slowed.
+- **Reuse guards** (prior learning `playwright-network-capture-hardening`):
+  `_MAX_CAPTURE_BYTES` and a per-action `asyncio.wait_for` so a stalled download can't
+  hang the single-process queue. Note (outside voice #9): for the download-event path the
+  size cap is **post-hoc** — Playwright streams to disk before `download.path()` is
+  readable, so the cap is checked after the file is written (acceptable on the NAS;
+  discard + None if over). Wrap click+save in try/except: any exception (element detached,
+  click intercepted) falls through to `page.pdf()`.
+- New `FetchResult.method` value: `"playwright_download_click"`.
+
+### Change 2 — surface the viewer-shell fallback
+
+`page.pdf()` fallback (step 4) is a last-resort screenshot-of-a-webpage, not a real
+document. Mark it so downstream can route it to review.
+
+- Set a flag on `FetchResult` for the shell capture. Reuse the existing
+  `auth_wall`-style downgrade path rather than inventing a parallel mechanism:
+  add `FetchResult.page_capture: bool = False`, set `True` on the step-4
+  `playwright_capture` return (NOT on the auth-wall capture, which already downgrades).
+- Scope of the downgrade (eng-review decision, finding 2 → **all** `page.pdf()` captures):
+  `page_capture=True` is set on EVERY step-4 `playwright_capture` fallback (a page.pdf()
+  capture is by definition "we couldn't get the real file"), and always routes to
+  `needs_review`. Not narrowed to "a control was seen" — the mast bug was an *unrecognized*
+  control, so narrowing would re-open the exact hole.
+- In `gmail.py::_ingest_url` (line ~340), extend the existing downgrade:
+  `if fetch_result.auth_wall or fetch_result.page_capture: status = "needs_review"`,
+  and set `user_notes` ("Captured viewer page render, not a downloaded file — verify the PDF").
+- **`telegram.py` needs the SAME fix (confirmed).** `telegram.py:125` today downgrades only
+  on `auth_wall` (`if result.auth_wall: status = "needs_review"` else `"pending"`). Add
+  `or result.page_capture` there too, or the silent-success bug persists for Telegram-submitted
+  viewer URLs. Both callers are in scope.
+
+### Change 3 — mast.co.il site handler (added during implementation, T5 finding)
+
+Live verification (T5) proved the generic button-click CANNOT capture the mast bill:
+the viewer nests content in an iframe + a shadow-DOM web component (`APP-BILL-VIEWER-LIST`),
+labels the control in Hebrew ("שובר"/"צפייה", not "download"), and loads an invisible
+reCAPTCHA v3. The generic path only ever captured the 1-page viewer shell.
+
+But the SPA fetches the bill from a **public JSON API keyed by the same guid** that is in
+the viewer URL, and that JSON carries a direct `pdfLink` (Azure blob). No browser, no
+shadow DOM, no CAPTCHA needed. So a deterministic site handler is the correct fix:
+
+```
+mast.co.il/bill-viewer/<guid>
+  → GET api.mast.co.il/mast/api/Stubs/GetStubsByGuidForPresentingStubs?guid=<guid>   (JSON)
+  → stubExtentionList[].pdfLink  →  GET Azure blob  →  real PDF   (method="mast_api")
+```
+
+- `_mast_guid(url)` detects `mast.co.il`/`www.mast.co.il` + `/bill-viewer/<guid>` and
+  URL-decodes the guid; `_fetch_mast_bill` calls the API, follows the first `pdfLink`
+  (logs when a period carries >1 stub — one file per URL), SSRF-checks the blob URL,
+  size-caps, returns `method="mast_api"`.
+- Wired at the TOP of `fetch_url` (after the SSRF gate, before the generic path). Returns
+  None on any failure so a mast API change can't strand ingestion — it degrades to the
+  generic path → `page.pdf()` → `page_capture` → needs_review.
+- Verified live: returns the real 2-page / 680,854-byte bill, matching hand-submitted
+  doc 185 (2 pages / 680,886 B).
+
+This is the "known-viewer registry" the plan had deferred — justified now because it is a
+clean, deterministic API call (not the brittle DOM crawler the deferral worried about).
+Kept as a single named handler, not a registry abstraction (YAGNI until a 2nd site).
+
+### Data flow after the fix
+
+```
+email URL ─▶ fetch_url ─▶ httpx GET (text/html)
+                          ─▶ _find_document_links (static)      ── none
+                          ─▶ _playwright_fetch
+                               (1) streamed application/pdf?     ── real PDF ✓ (method=playwright_network)
+                               (3) <a href> doc link?            ── real PDF ✓ (method=playwright_download)
+                               (3b) button-click download?  ◀── mast lands here ▶ real PDF ✓ (method=playwright_download_click)
+                               (4) page.pdf() shell             ── page_capture=True ▶ needs_review
+```
+
+## Edge cases
+
+- Multiple download-like buttons (print vs download vs share): rank PDF/download
+  keywords above print; take the single best; never click more than one.
+- Button triggers a same-tab navigation to a PDF instead of a download event: covered
+  by `page.expect_download` (Chromium fires `download` for `application/pdf` responses
+  with content-disposition); if it navigates and renders instead, we still fall to
+  page.pdf() → needs_review (no regression).
+- Download saves a non-document (html/zip): existing `normalize`/classify already gates
+  this; the fetched file still runs through `_render_first_page_from_file` + LLM classify
+  in `_process_urls`, so a junk download is discarded like any non-qualifying URL.
+- No Chromium / playwright missing: unchanged — `_playwright_fetch` already returns None
+  on ImportError.
+- Click throws / element detaches: catch, fall through to page.pdf() fallback.
+
+## Test plan (mirroring #27's mocked-Playwright style)
+
+`tests/test_url_fetcher.py` (existing patterns: patch `httpx.AsyncClient`, patch
+`_playwright_fetch`/playwright objects with AsyncMock):
+
+1. Button-click happy path: mocked page with a Hebrew "הורדה" button; `expect_download`
+   yields a temp PDF → `FetchResult.method == "playwright_download_click"`, file saved,
+   `page_capture == False`.
+2. English "Download" button → same.
+3. Keyword matcher matches on `aria-label`/`title`, not just visible text.
+4. Ranking + denylist: page with "print", "הורדה", and a "שלם/pay" button → clicks the
+   download control, NEVER the pay control.
+5. No download control + no stream + no link → `page.pdf()` fallback returns
+   `page_capture=True`, `method="playwright_capture"`.
+6. **[gap→added]** Click raises / element detaches → caught, falls to `page.pdf()`
+   fallback (`page_capture=True`), no crash.
+7. **[gap→added]** Download event never fires within the detect window (button navigated
+   instead) → falls to `page.pdf()` fallback (`page_capture=True`).
+8. **[gap→added, regression guard]** Auth-wall `page.pdf()` capture sets `auth_wall=True`
+   but `page_capture=False` — the auth path is unchanged and not double-counted.
+9. SSRF re-check rejects a download whose resolved URL is private.
+10. Size cap: oversized download discarded (`_MAX_CAPTURE_BYTES`).
+
+`tests/test_gmail_urls.py` (where `_ingest_url` is covered):
+
+11. `_ingest_url` with `page_capture=True` → status `needs_review` + user_notes set;
+    and `auth_wall=True` still → `needs_review` (unchanged).
+
+`tests/test_telegram_urls.py`:
+
+12. **[gap→added, 2nd caller]** Telegram URL ingest with `page_capture=True` → status
+    `needs_review` (today it would be `pending` — this is the regression the fix closes
+    for Telegram).
+
+**Live verification (MANDATORY — outside voice #5, not optional).** Mocked tests prove
+the plumbing, not the capture — the original bug hid *because* unit behavior looked fine
+while real capture silently failed. Before shipping, fetch the live
+`mast.co.il/bill-viewer/<token>` URL (from doc 266) through `fetch_url` and assert the
+captured PDF is the **real multi-page bill** — page_count and size in the ballpark of
+doc 185 (2 pages / ~680 KB), NOT a 1-page / ~300 KB shell. This is the metric from the
+issue's own evidence; a mocked-only suite cannot catch a recurrence.
+
+## NOT in scope
+
+- **Remediating already-ingested shell docs (outside voice #6, eng-review decision → by hand).**
+  The fix is forward-only: Gmail marked those emails `\Seen` and `unread_only` won't re-poll
+  them, so doc 266 and any prior viewer-shell captures stay wrong. Decision: **no remediation
+  code.** Re-submit doc 266 by hand (as doc 185 was) once the fix ships. Accepted risk: other
+  already-ingested shells stay silently wrong with no automated way to find them (single-user
+  NAS, low volume — acceptable).
+- Site-specific handler / known-viewer registry for mast/outbox (only if the generic
+  button-click proves brittle in practice — deferred, noted in issue #32).
+- Retrying/queuing the click across multiple candidates (single best-candidate click only).
+- Distribution/pipeline changes (none — internal web service).
+
+## Files
+
+- `backend/ingestion/url_fetcher.py` — `_playwright_fetch` (new step 3b button-click),
+  `DOWNLOAD_KEYWORDS` → multilingual shared matcher, `FetchResult` (+`page_capture` bool,
+  +`playwright_download_click` method), ranking/denylist helper.
+- `backend/ingestion/gmail.py` — `_ingest_url` (line ~340) downgrade on `page_capture`.
+- `backend/ingestion/telegram.py` — line ~125 downgrade on `page_capture` (confirmed needed).
+- `tests/test_url_fetcher.py` — tests 1-10.
+- `tests/test_gmail_urls.py` — test 11.
+- `tests/test_telegram_urls.py` — test 12.
+
+## What already exists (reused, not rebuilt)
+
+- `_playwright_fetch` streamed-`application/pdf` capture (`_on_response` + `_read_streamed_pdf`,
+  #27) — reused and now kept alive across the click (dual capture).
+- `_find_document_links` + `DOWNLOAD_KEYWORDS` — reused unchanged for the static `<a>` scan;
+  the click path gets a separate net.
+- Guards `_is_safe_url`, `_MAX_CAPTURE_BYTES`, `_MIN_RENDER_TIMEOUT` — reused (with the
+  blob/data carve-out on `_is_safe_url` for the download path).
+- `auth_wall → needs_review` downgrade in `gmail._ingest_url` and `telegram` — the
+  `page_capture` downgrade extends this exact branch, not a parallel mechanism.
+
+## Failure modes (new codepaths)
+
+| Failure | Test? | Error handling? | User sees |
+|---------|-------|-----------------|-----------|
+| Click navigates instead of downloading | yes (#7) | falls to page.pdf() | needs_review (not silent) ✓ |
+| Click raises / element detaches | yes (#6) | try/except → page.pdf() | needs_review ✓ |
+| blob:/data: download URL | yes (#1 happy) | allowed past `_is_safe_url` | real PDF ✓ |
+| PDF served inline, no download event | covered by dual capture (#2) | `_on_response` catches it | real PDF ✓ |
+| Download exceeds size cap | yes (#10) | post-hoc discard → None → page.pdf() | needs_review ✓ |
+| Build-on-click PDF slower than 15s | (live verify #live) | times out → page.pdf() | needs_review (not silent) ✓ |
+
+No new **silent** failure mode: every miss lands in `page.pdf()` → `page_capture=True` →
+`needs_review`. That is the whole point of Change 2.
+
+## Worktree parallelization strategy
+
+Sequential implementation, no parallelization opportunity — every change lives in
+`backend/ingestion/` (url_fetcher is the core; gmail + telegram are 1-line downgrades that
+depend on the `page_capture` field the core adds). One lane.
+
+## Implementation Tasks
+Synthesized from this review's findings. Each derives from a finding above.
+
+- [ ] **T1 (P1, human: ~3h / CC: ~25min)** — url_fetcher — add step 3b dual-capture button-click download
+  - Surfaced by: Architecture finding 1 + outside voice #1/#2 — client-generated PDF (blob or inline) behind a JS button
+  - Files: `backend/ingestion/url_fetcher.py` (`_playwright_fetch`, new `_CLICK_DOWNLOAD_KEYWORDS`, ranking/denylist helper, blob/data carve-out, keep `_on_response` alive across click, `expect_download`, 15s window)
+  - Verify: `test_url_fetcher.py` tests 1-10
+- [ ] **T2 (P1, human: ~30min / CC: ~5min)** — url_fetcher — `FetchResult.page_capture` set on the page.pdf() fallback only
+  - Surfaced by: Architecture finding 2 — stop silent success
+  - Files: `backend/ingestion/url_fetcher.py` (`FetchResult`, step-4 return)
+  - Verify: test #5, #8 (auth_wall regression guard)
+- [ ] **T3 (P1, human: ~30min / CC: ~5min)** — ingestion — downgrade `page_capture` → needs_review in BOTH callers
+  - Surfaced by: finding 2 + outside voice #7 — telegram has the identical hole
+  - Files: `backend/ingestion/gmail.py` (~340), `backend/ingestion/telegram.py` (~125)
+  - Verify: `test_gmail_urls.py` #11, `test_telegram_urls.py` #12
+- [ ] **T4 (P1, human: ~2h / CC: ~15min)** — tests — 12 mocked-Playwright tests
+  - Surfaced by: Test review — 4 gaps + happy paths
+  - Files: `test_url_fetcher.py`, `test_gmail_urls.py`, `test_telegram_urls.py`
+  - Verify: `uv run pytest tests/test_url_fetcher.py tests/test_gmail_urls.py tests/test_telegram_urls.py`
+- [ ] **T5 (P1, human: ~15min / CC: ~10min)** — verification — live capture against doc 266's mast URL
+  - Surfaced by: outside voice #5 — mocked tests can't catch real-capture recurrence
+  - Verify: fetched PDF ≈ doc 185 (2 pages / ~680 KB), not a 1-page shell
+
+## GSTACK REVIEW REPORT
+
+| Review | Trigger | Why | Runs | Status | Findings |
+|--------|---------|-----|------|--------|----------|
+| CEO Review | `/plan-ceo-review` | Scope & strategy | 0 | — | not run (bug fix) |
+| Eng Review | `/plan-eng-review` | Architecture & tests (required) | 1 | CLEAR | 6 issues, 0 critical gaps — all folded |
+| Design Review | `/plan-design-review` | UI/UX gaps | 0 | — | not run (backend-only) |
+| Outside Voice | Claude subagent | Independent plan challenge | 1 | issues_found | 9 raised; 6 substantive folded, 3 minor noted |
+
+**Completion summary**
+- Step 0: scope accepted as-is (~5 files, 0 new classes — under threshold)
+- Architecture: 2 findings (guarded single-click; page_capture→needs_review) — both folded
+- Code Quality: 0 blocking (DRY note superseded by finding-3 two-nets decision)
+- Test Review: diagram produced, 4 gaps → all added (12 tests + mandatory live verification)
+- Performance: 1 note (15s window, post-click only) — folded
+- Outside Voice: ran (Claude subagent, Codex not installed); 6 substantive findings folded
+  (#1 blob/data SSRF carve-out, #2 dual capture, #3 two scoped nets, #4 15s window,
+  #5 live verification, #6 forward-only stated), 3 minor noted (#7 already committed,
+  #8 dropped submit-input, #9 post-hoc size cap)
+- NOT in scope: written (remediation forward-only; known-viewer registry; single-click)
+- Failure modes: 0 critical gaps — every miss routes to needs_review, none silent
+- TODOS.md: 0 added (remediation chosen as by-hand, no code)
+- Parallelization: 1 lane, sequential (all in backend/ingestion/)
+
+**OUTSIDE VOICE:** headline catch — reusing `_is_safe_url` on the download URL would
+reject a `blob:`/`data:` client-generated PDF and silently defeat the fix; folded a
+scheme carve-out + dual capture. Same model family (Codex unavailable), weighed accordingly.
+
+**VERDICT:** ENG CLEARED — ready to implement. Bug fix; CEO/Design review not required.
+
+NO UNRESOLVED DECISIONS

--- a/tests/test_gmail_urls.py
+++ b/tests/test_gmail_urls.py
@@ -100,3 +100,130 @@ class TestCollectAttachments:
         assert len(atts) == 0
 
 
+def _make_fetched_file(tmp_data_dir, name, content):
+    """Create a real fetched file on disk for _ingest_url to hash/save.
+
+    _ingest_url computes a hash and copies the original, so the file must
+    exist. Content is caller-supplied to keep each test's hash unique and
+    avoid the SHA-256 duplicate-rejection path.
+    """
+    import os
+
+    tmp_dir = os.path.join(str(tmp_data_dir), "storage", "tmp")
+    os.makedirs(tmp_dir, exist_ok=True)
+    file_path = os.path.join(tmp_dir, name)
+    with open(file_path, "wb") as f:
+        f.write(content)
+    return file_path
+
+
+class TestIngestUrlPageCapture:
+    """Issue #32: a page.pdf() viewer-shell capture must route to needs_review,
+    not be filed as a successfully processed real document."""
+
+    def test_page_capture_routes_to_needs_review(self, db_path, tmp_data_dir):
+        """page_capture=True (authorized) -> needs_review with a verify note."""
+        from backend.ingestion.gmail import _ingest_url
+        from backend.ingestion.url_fetcher import FetchResult
+        from backend.database import get_connection
+
+        url = "https://www.mast.co.il/bill-viewer/jpIBk123"
+        fake_file = _make_fetched_file(
+            tmp_data_dir, "capture.pdf",
+            b"%PDF-1.4 viewer shell page capture unique content 32a",
+        )
+        fetch_result = FetchResult(
+            file_path=fake_file,
+            content_type="application/pdf",
+            original_url=url,
+            page_capture=True,
+            method="playwright_capture",
+        )
+
+        result = _ingest_url(url, "biller@mast.co.il", str(tmp_data_dir), True,
+                             fetch_result=fetch_result)
+        assert result["status"] == "ingested"
+
+        with get_connection() as conn:
+            doc = conn.execute(
+                "SELECT * FROM documents WHERE source_url = ?", (url,)
+            ).fetchone()
+
+        assert doc is not None
+        # Downgraded despite an authorized sender.
+        assert doc["status"] == "needs_review"
+        assert doc["status"] != "pending"
+        # user_notes set, non-empty, and tells the user to verify the PDF.
+        notes = doc["user_notes"] or ""
+        assert notes.strip()
+        assert "verify the pdf" in notes.lower()
+
+    def test_normal_authorized_url_stays_pending(self, db_path, tmp_data_dir):
+        """page_capture=False, auth_wall=False (authorized) -> pending.
+
+        Proves the downgrade is specific to page_capture, not applied to
+        every authorized URL ingest."""
+        from backend.ingestion.gmail import _ingest_url
+        from backend.ingestion.url_fetcher import FetchResult
+        from backend.database import get_connection
+
+        url = "https://vendor.example.com/invoice/direct.pdf"
+        fake_file = _make_fetched_file(
+            tmp_data_dir, "direct.pdf",
+            b"%PDF-1.4 real downloaded document unique content 32b",
+        )
+        fetch_result = FetchResult(
+            file_path=fake_file,
+            content_type="application/pdf",
+            original_url=url,
+            page_capture=False,
+            auth_wall=False,
+            method="direct",
+        )
+
+        result = _ingest_url(url, "vendor@example.com", str(tmp_data_dir), True,
+                             fetch_result=fetch_result)
+        assert result["status"] == "ingested"
+
+        with get_connection() as conn:
+            doc = conn.execute(
+                "SELECT * FROM documents WHERE source_url = ?", (url,)
+            ).fetchone()
+
+        assert doc is not None
+        assert doc["status"] == "pending"
+        assert not (doc["user_notes"] or "").strip()
+
+    def test_auth_wall_still_needs_review(self, db_path, tmp_data_dir):
+        """auth_wall=True (authorized) -> needs_review (unchanged behavior)."""
+        from backend.ingestion.gmail import _ingest_url
+        from backend.ingestion.url_fetcher import FetchResult
+        from backend.database import get_connection
+
+        url = "https://portal.example.com/login/invoice/99"
+        fake_file = _make_fetched_file(
+            tmp_data_dir, "authwall.pdf",
+            b"%PDF-1.4 login page capture unique content 32c",
+        )
+        fetch_result = FetchResult(
+            file_path=fake_file,
+            content_type="application/pdf",
+            original_url=url,
+            auth_wall=True,
+            method="playwright_capture",
+        )
+
+        result = _ingest_url(url, "portal@example.com", str(tmp_data_dir), True,
+                             fetch_result=fetch_result)
+        assert result["status"] == "ingested"
+
+        with get_connection() as conn:
+            doc = conn.execute(
+                "SELECT * FROM documents WHERE source_url = ?", (url,)
+            ).fetchone()
+
+        assert doc is not None
+        assert doc["status"] == "needs_review"
+        assert "auth" in (doc["user_notes"] or "").lower()
+
+

--- a/tests/test_telegram_urls.py
+++ b/tests/test_telegram_urls.py
@@ -190,6 +190,107 @@ async def test_text_triage_filters_all(db_path, tmp_data_dir):
 
 
 @pytest.mark.asyncio
+async def test_text_page_capture_url(db_path, tmp_data_dir):
+    """Viewer-shell page capture (page_capture=True) should route to
+    needs_review with user_notes set — regression for issue #32.
+
+    Before the fix, page.pdf() viewer-shell captures were filed as 'pending',
+    hiding the capture failure. The companion assertion confirms the downgrade
+    is specific to page_capture: a plain fetch stays 'pending'.
+    """
+    from backend.ingestion.telegram import handle_text
+    from backend.database import get_connection
+
+    tmp_dir = os.path.join(str(tmp_data_dir), "storage", "tmp")
+    os.makedirs(tmp_dir, exist_ok=True)
+
+    # --- page_capture=True → needs_review ---
+    capture_url = "https://viewer.example.com/doc/abc"
+    capture_file = os.path.join(tmp_dir, "pagecapture.pdf")
+    with open(capture_file, "wb") as f:
+        f.write(b"%PDF-1.4 viewer shell page capture")
+
+    capture_result = FetchResult(
+        file_path=capture_file,
+        content_type="application/pdf",
+        original_url=capture_url,
+        auth_wall=False,
+        page_capture=True,
+        method="playwright_capture",
+    )
+
+    update = _make_update(text=f"Receipt here: {capture_url}")
+    context = _make_context(tmp_data_dir)
+
+    with (
+        patch("backend.ingestion.telegram._is_authorized", return_value=True),
+        patch(
+            "backend.ingestion.telegram.triage_telegram_urls",
+            new_callable=AsyncMock,
+            return_value=[capture_url],
+        ),
+        patch(
+            "backend.ingestion.telegram.fetch_url",
+            new_callable=AsyncMock,
+            return_value=capture_result,
+        ),
+        patch("backend.ingestion.telegram.notify", create=True),
+    ):
+        await handle_text(update, context)
+
+    with get_connection() as conn:
+        doc = conn.execute(
+            "SELECT * FROM documents WHERE source_url = ?", (capture_url,)
+        ).fetchone()
+
+    assert doc is not None
+    assert doc["status"] == "needs_review"
+    assert doc["user_notes"] is not None and doc["user_notes"] != ""
+
+    # --- page_capture=False, auth_wall=False → pending (downgrade is specific) ---
+    plain_url = "https://example.com/plain-invoice.pdf"
+    plain_file = os.path.join(tmp_dir, "plainfile.pdf")
+    with open(plain_file, "wb") as f:
+        f.write(b"%PDF-1.4 real downloaded file")
+
+    plain_result = FetchResult(
+        file_path=plain_file,
+        content_type="application/pdf",
+        original_url=plain_url,
+        auth_wall=False,
+        page_capture=False,
+        method="direct",
+    )
+
+    update = _make_update(text=f"Receipt here: {plain_url}")
+    context = _make_context(tmp_data_dir)
+
+    with (
+        patch("backend.ingestion.telegram._is_authorized", return_value=True),
+        patch(
+            "backend.ingestion.telegram.triage_telegram_urls",
+            new_callable=AsyncMock,
+            return_value=[plain_url],
+        ),
+        patch(
+            "backend.ingestion.telegram.fetch_url",
+            new_callable=AsyncMock,
+            return_value=plain_result,
+        ),
+        patch("backend.ingestion.telegram.notify", create=True),
+    ):
+        await handle_text(update, context)
+
+    with get_connection() as conn:
+        doc = conn.execute(
+            "SELECT * FROM documents WHERE source_url = ?", (plain_url,)
+        ).fetchone()
+
+    assert doc is not None
+    assert doc["status"] == "pending"
+
+
+@pytest.mark.asyncio
 async def test_text_fetch_returns_none(db_path, tmp_data_dir):
     """When fetch_url returns None, reply with error and no document created."""
     from backend.ingestion.telegram import handle_text

--- a/tests/test_url_fetcher.py
+++ b/tests/test_url_fetcher.py
@@ -498,3 +498,448 @@ class TestPlaywrightNetworkPdfCapture:
         # Bailed at the detect window, not the full settle window.
         assert page.wait_for_timeout.await_count == url_fetcher._DOC_STREAM_DETECT
         assert url_fetcher._DOC_STREAM_DETECT < url_fetcher._DOC_STREAM_SETTLE
+
+
+# ---------------------------------------------------------------------------
+# Issue #32: button-click download capture (_try_click_download)
+# ---------------------------------------------------------------------------
+
+from playwright.async_api import TimeoutError as PlaywrightTimeoutError
+
+from backend.ingestion.url_fetcher import _try_click_download
+
+
+def _fake_element(inner_text="", attrs=None, visible=True, enabled=True):
+    """A mock Playwright element handle for a clickable control.
+
+    `attrs` maps aria-label/title/value/download -> value (missing -> None).
+    """
+    attrs = attrs or {}
+    el = MagicMock()
+    el.is_visible = AsyncMock(return_value=visible)
+    el.is_enabled = AsyncMock(return_value=enabled)
+    el.inner_text = AsyncMock(return_value=inner_text)
+
+    async def _get_attribute(name):
+        return attrs.get(name)
+
+    el.get_attribute = AsyncMock(side_effect=_get_attribute)
+    el.click = AsyncMock()
+    return el
+
+
+def _fake_download(tmp_path, url="blob:https://example.com/abc", body=b"%PDF-1.4 downloaded doc", suggested="invoice.pdf"):
+    """A mock Playwright Download whose path() points at real bytes on disk."""
+    import uuid as _uuid
+    disk = tmp_path / f"pw-dl-{_uuid.uuid4().hex}"
+    disk.write_bytes(body)
+    dl = MagicMock()
+    dl.url = url
+    dl.suggested_filename = suggested
+    dl.path = AsyncMock(return_value=str(disk))
+    return dl
+
+
+class _ExpectDownloadCM:
+    """Async context manager standing in for page.expect_download(...).
+
+    On enter yields an info object whose `.value` awaits to `download`. If
+    `aexit_exc` is set it is raised from __aexit__ (simulates no download event
+    within the timeout — Playwright raises TimeoutError there).
+    """
+
+    def __init__(self, download=None, aexit_exc=None, value_exc=None):
+        self._download = download
+        self._aexit_exc = aexit_exc
+        self._value_exc = value_exc
+
+    async def __aenter__(self):
+        info = MagicMock()
+
+        async def _value():
+            if self._value_exc is not None:
+                raise self._value_exc
+            return self._download
+
+        # `.value` is awaited by the source: `download = await dl_info.value`.
+        type(info).value = property(lambda _self: _value())
+        return info
+
+    async def __aexit__(self, exc_type, exc, tb):
+        if self._aexit_exc is not None and exc_type is None:
+            raise self._aexit_exc
+        return False  # never suppress a click exception
+
+
+def _click_page(elements, expect_cm, url="https://example.com/bill-viewer"):
+    """A mock Playwright Page for driving _try_click_download directly."""
+    page = MagicMock()
+    page.url = url
+    page.query_selector_all = AsyncMock(return_value=elements)
+    page.expect_download = MagicMock(return_value=expect_cm)
+    page.wait_for_timeout = AsyncMock()
+    return page
+
+
+@pytest.mark.asyncio
+class TestTryClickDownload:
+    """Issue #32: click the single best download control and capture the PDF."""
+
+    async def test_hebrew_download_button_captures(self, tmp_path):
+        pdf = b"%PDF-1.4 hebrew download"
+        el = _fake_element(inner_text="הורדה")
+        dl = _fake_download(tmp_path, url="blob:https://mast.co.il/x", body=pdf)
+        page = _click_page([el], _ExpectDownloadCM(download=dl))
+
+        result = await _try_click_download(page, str(tmp_path), [])
+
+        assert result is not None
+        assert result.method == "playwright_download_click"
+        assert result.page_capture is False
+        assert result.content_type == "application/pdf"
+        assert Path(result.file_path).read_bytes() == pdf
+        el.click.assert_awaited_once()
+
+    async def test_english_download_button_captures(self, tmp_path):
+        pdf = b"%PDF-1.4 english download"
+        el = _fake_element(inner_text="Download")
+        dl = _fake_download(tmp_path, url="blob:https://example.com/y", body=pdf)
+        page = _click_page([el], _ExpectDownloadCM(download=dl))
+
+        result = await _try_click_download(page, str(tmp_path), [])
+
+        assert result is not None
+        assert result.method == "playwright_download_click"
+        assert result.page_capture is False
+        assert Path(result.file_path).read_bytes() == pdf
+        el.click.assert_awaited_once()
+
+    async def test_keyword_match_via_aria_label_only(self, tmp_path):
+        # Empty visible text; the keyword lives only in aria-label.
+        pdf = b"%PDF-1.4 aria download"
+        el = _fake_element(inner_text="", attrs={"aria-label": "Download invoice"})
+        dl = _fake_download(tmp_path, url="blob:https://example.com/z", body=pdf)
+        page = _click_page([el], _ExpectDownloadCM(download=dl))
+
+        result = await _try_click_download(page, str(tmp_path), [])
+
+        assert result is not None
+        assert result.method == "playwright_download_click"
+        assert Path(result.file_path).read_bytes() == pdf
+        el.click.assert_awaited_once()
+
+    async def test_ranking_and_denylist(self, tmp_path):
+        # Four controls: an ignored non-match, a weak keyword match, the strong
+        # download control, and a denylisted money-mover that also matches a
+        # keyword. Only the strong download control must be clicked.
+        print_btn = _fake_element(inner_text="Print")
+        weak = _fake_element(inner_text="Invoice")              # rank 1 (keyword only)
+        strong = _fake_element(inner_text="הורדה")              # rank 0 (strong)
+        pay = _fake_element(inner_text="שלם חשבונית")           # keyword + denylist -> excluded
+
+        dl = _fake_download(tmp_path, url="blob:https://example.com/dl", body=b"%PDF-1.4 x")
+        page = _click_page([print_btn, weak, strong, pay], _ExpectDownloadCM(download=dl))
+
+        result = await _try_click_download(page, str(tmp_path), [])
+
+        assert result is not None
+        assert result.method == "playwright_download_click"
+        # The strong download control wins ranking and is the only one clicked.
+        strong.click.assert_awaited_once()
+        weak.click.assert_not_awaited()
+        print_btn.click.assert_not_awaited()
+        # The money-moving control is NEVER clicked, even though it matched a keyword.
+        pay.click.assert_not_awaited()
+
+    async def test_click_raises_returns_none(self, tmp_path):
+        # A click that raises must not crash; _try_click_download returns None so
+        # the caller falls back to the page.pdf() capture path.
+        el = _fake_element(inner_text="Download")
+        el.click = AsyncMock(side_effect=Exception("element detached"))
+        page = _click_page([el], _ExpectDownloadCM(download=_fake_download(tmp_path)))
+
+        result = await _try_click_download(page, str(tmp_path), [])
+
+        assert result is None
+        el.click.assert_awaited_once()
+
+    async def test_no_download_event_no_inline_returns_none(self, tmp_path):
+        # expect_download times out (no download fired) and no inline PDF was
+        # streamed -> None.
+        el = _fake_element(inner_text="Download")
+        page = _click_page([el], _ExpectDownloadCM(aexit_exc=PlaywrightTimeoutError("no download")))
+
+        result = await _try_click_download(page, str(tmp_path), [])
+
+        assert result is None
+        el.click.assert_awaited_once()
+
+    async def test_no_download_event_but_inline_pdf_captured(self, tmp_path):
+        # No download event, but the click streamed an inline application/pdf
+        # response -> captured via the inline path.
+        el = _fake_element(inner_text="Download")
+        inline = _fake_pdf_response(body=b"%PDF-1.4 inline after click")
+        page = _click_page([el], _ExpectDownloadCM(aexit_exc=PlaywrightTimeoutError("no download")))
+
+        result = await _try_click_download(page, str(tmp_path), [inline])
+
+        assert result is not None
+        assert result.method == "playwright_download_click"
+        assert result.content_type == "application/pdf"
+        assert Path(result.file_path).read_bytes() == b"%PDF-1.4 inline after click"
+
+    async def test_no_matching_control_returns_none(self, tmp_path):
+        # Controls exist but none match the download keyword net.
+        page = _click_page(
+            [_fake_element(inner_text="Home"), _fake_element(inner_text="Settings")],
+            _ExpectDownloadCM(download=_fake_download(tmp_path)),
+        )
+
+        result = await _try_click_download(page, str(tmp_path), [])
+
+        assert result is None
+
+    async def test_unsafe_http_download_url_rejected(self, tmp_path):
+        # A download whose URL is a real http(s) URL that _is_safe_url rejects
+        # must not be captured (SSRF) -> None.
+        el = _fake_element(inner_text="Download")
+        dl = _fake_download(tmp_path, url="http://169.254.169.254/latest/meta-data")
+        page = _click_page([el], _ExpectDownloadCM(download=dl))
+
+        with patch("backend.ingestion.url_fetcher._is_safe_url", return_value=False):
+            result = await _try_click_download(page, str(tmp_path), [])
+
+        assert result is None
+
+    async def test_blob_download_captured_when_page_origin_safe(self, tmp_path):
+        # blob: URLs are browser-created, so they skip the http(s) SSRF check
+        # and are captured when the page's own origin is safe (the default).
+        pdf = b"%PDF-1.4 blob doc"
+        el = _fake_element(inner_text="Download")
+        dl = _fake_download(tmp_path, url="blob:https://example.com/blobbie", body=pdf)
+        page = _click_page([el], _ExpectDownloadCM(download=dl))
+
+        result = await _try_click_download(page, str(tmp_path), [])
+
+        assert result is not None
+        assert result.method == "playwright_download_click"
+        assert Path(result.file_path).read_bytes() == pdf
+
+    async def test_blob_download_rejected_when_page_origin_unsafe(self, tmp_path):
+        # Security (issue #32): a blob download from an UNSAFE page origin is
+        # rejected — a safe-looking page could have fetched internal bytes into
+        # a blob. _is_safe_url(page.url) is the gate for blob/data.
+        el = _fake_element(inner_text="Download")
+        dl = _fake_download(tmp_path, url="blob:https://example.com/blobbie", body=b"%PDF internal")
+        page = _click_page([el], _ExpectDownloadCM(download=dl))
+
+        with patch("backend.ingestion.url_fetcher._is_safe_url", return_value=False):
+            result = await _try_click_download(page, str(tmp_path), [])
+
+        assert result is None
+
+    async def test_oversized_download_discarded(self, tmp_path):
+        # A downloaded body over the size cap is discarded; with no inline PDF
+        # fallback the attempt returns None.
+        from backend.ingestion import url_fetcher
+
+        el = _fake_element(inner_text="Download")
+        dl = _fake_download(tmp_path, url="blob:https://example.com/big", body=b"x" * 64)
+        page = _click_page([el], _ExpectDownloadCM(download=dl))
+
+        with patch.object(url_fetcher, "_MAX_CAPTURE_BYTES", 16):
+            result = await _try_click_download(page, str(tmp_path), [])
+
+        assert result is None
+
+    async def test_hidden_or_disabled_control_skipped(self, tmp_path):
+        # A matching download control that is not visible/enabled is skipped;
+        # with no other candidate, returns None (caller falls back to page.pdf()).
+        hidden = _fake_element(inner_text="הורדה", visible=False)
+        disabled = _fake_element(inner_text="Download", enabled=False)
+        page = _click_page([hidden, disabled], _ExpectDownloadCM(download=None))
+        result = await _try_click_download(page, str(tmp_path), [])
+        assert result is None
+        hidden.click.assert_not_awaited()
+        disabled.click.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+class TestPlaywrightFetchClickAndCaptureFallback:
+    """Issue #32: end-to-end _playwright_fetch behaviour around click capture."""
+
+    async def test_falls_to_page_capture_flags_page_capture(self, tmp_path):
+        # No load-time PDF stream, no <a> links, and no matching download
+        # control -> the viewer-shell page.pdf() capture, flagged page_capture.
+        page = MagicMock()
+        page.on = MagicMock()
+        page.url = "https://example.com/viewer"
+        page.goto = AsyncMock()
+        page.wait_for_timeout = AsyncMock()
+        # [] for password fields AND for the click-download control scan.
+        page.query_selector_all = AsyncMock(return_value=[])
+        page.content = AsyncMock(return_value="<html><body>viewer shell</body></html>")
+        page.pdf = AsyncMock(return_value=b"%PDF-1.4 shell capture")
+
+        with patch(
+            "playwright.async_api.async_playwright",
+            _make_playwright_mock(page),
+        ):
+            result = await _playwright_fetch(
+                "https://example.com/viewer", str(tmp_path), timeout=5
+            )
+
+        assert result is not None
+        assert result.method == "playwright_capture"
+        assert result.page_capture is True
+        assert result.auth_wall is False
+        assert Path(result.file_path).read_bytes() == b"%PDF-1.4 shell capture"
+
+    async def test_auth_wall_capture_is_not_page_capture(self, tmp_path):
+        # The password-field branch produces an auth_wall capture that must NOT
+        # be flagged page_capture (it is intentionally routed differently).
+        password_field = MagicMock()
+        page = MagicMock()
+        page.on = MagicMock()
+        page.url = "https://example.com/login"
+        page.goto = AsyncMock()
+        page.wait_for_timeout = AsyncMock()
+        # Password branch is reached first and returns before the click scan.
+        page.query_selector_all = AsyncMock(return_value=[password_field])
+        page.content = AsyncMock(return_value="<html><body>login</body></html>")
+        page.pdf = AsyncMock(return_value=b"%PDF-1.4 login shell")
+
+        with patch(
+            "playwright.async_api.async_playwright",
+            _make_playwright_mock(page),
+        ):
+            result = await _playwright_fetch(
+                "https://example.com/login", str(tmp_path), timeout=5
+            )
+
+        assert result is not None
+        assert result.auth_wall is True
+        assert result.page_capture is False
+        assert result.method == "playwright_capture"
+
+    async def test_click_download_result_is_returned(self, tmp_path):
+        # When _try_click_download captures a real download, _playwright_fetch
+        # returns it and does NOT fall through to the page.pdf() shell capture.
+        page = MagicMock()
+        page.on = MagicMock()
+        page.url = "https://example.com/viewer"
+        page.goto = AsyncMock()
+        page.wait_for_timeout = AsyncMock()
+        page.query_selector_all = AsyncMock(return_value=[])  # no password fields
+        page.content = AsyncMock(return_value="<html><body>viewer</body></html>")
+        page.pdf = AsyncMock(return_value=b"%PDF-1.4 shell")  # must NOT be used
+        (tmp_path / "real.pdf").write_bytes(b"%PDF-1.4 real bill")
+        clicked = FetchResult(
+            file_path=str(tmp_path / "real.pdf"), content_type="application/pdf",
+            original_url="https://example.com/viewer", method="playwright_download_click",
+        )
+        with patch("playwright.async_api.async_playwright", _make_playwright_mock(page)), \
+             patch("backend.ingestion.url_fetcher._try_click_download", AsyncMock(return_value=clicked)):
+            result = await _playwright_fetch("https://example.com/viewer", str(tmp_path), timeout=5)
+        assert result is clicked
+        assert result.method == "playwright_download_click"
+        page.pdf.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# Mast.co.il bill-viewer site handler (issue #32)
+# ---------------------------------------------------------------------------
+
+import json as _json
+from backend.ingestion.url_fetcher import _mast_guid, _fetch_mast_bill
+
+
+def _mast_client(api_json, pdf_bytes=b"%PDF-1.4 real bill", pdf_status=200, pdf_ct="application/pdf"):
+    """Patched AsyncClient whose .get dispatches the mast API vs the pdfLink."""
+    async def fake_get(url, **kw):
+        if "GetStubsByGuid" in url:
+            return _make_response(200, _json.dumps(api_json).encode(), "application/json")
+        return _make_response(pdf_status, pdf_bytes, pdf_ct)
+    mc = AsyncMock()
+    mc.get = fake_get
+    mc.__aenter__ = AsyncMock(return_value=mc)
+    mc.__aexit__ = AsyncMock(return_value=False)
+    return mc
+
+
+class TestMastBillHandler:
+    def test_guid_detection(self):
+        assert _mast_guid("https://mast.co.il/bill-viewer/abc%2Fdef%3D%3D") == "abc/def=="
+        assert _mast_guid("https://www.mast.co.il/bill-viewer/xyz") == "xyz"
+        assert _mast_guid("https://evil.com/bill-viewer/xyz") is None
+        assert _mast_guid("https://mast.co.il/other/xyz") is None
+        assert _mast_guid("https://mast.co.il/bill-viewer/") is None
+
+    async def test_fetch_bill_happy(self, tmp_path):
+        api = {"stubExtentionList": [{"pdfLink": "https://sabillsprod.blob.core.windows.net/orda/x.pdf"}]}
+        with patch("backend.ingestion.url_fetcher.httpx.AsyncClient", return_value=_mast_client(api)):
+            r = await _fetch_mast_bill("https://mast.co.il/bill-viewer/abc", str(tmp_path), 5)
+        assert r is not None and r.method == "mast_api" and not r.page_capture
+        assert Path(r.file_path).read_bytes() == b"%PDF-1.4 real bill"
+
+    async def test_multistub_takes_first(self, tmp_path):
+        api = {"stubExtentionList": [
+            {"pdfLink": "https://sabillsprod.blob.core.windows.net/a.pdf"},
+            {"pdfLink": "https://sabillsprod.blob.core.windows.net/b.pdf"},
+        ]}
+        with patch("backend.ingestion.url_fetcher.httpx.AsyncClient", return_value=_mast_client(api)):
+            r = await _fetch_mast_bill("https://mast.co.il/bill-viewer/abc", str(tmp_path), 5)
+        assert r is not None and r.method == "mast_api"
+
+    async def test_no_pdflink_returns_none(self, tmp_path):
+        api = {"stubExtentionList": []}
+        with patch("backend.ingestion.url_fetcher.httpx.AsyncClient", return_value=_mast_client(api)):
+            r = await _fetch_mast_bill("https://mast.co.il/bill-viewer/abc", str(tmp_path), 5)
+        assert r is None
+
+    async def test_api_http_error_returns_none(self, tmp_path):
+        async def fake_get(url, **kw):
+            return _make_response(500, b"err", "text/html")
+        mc = AsyncMock(); mc.get = fake_get
+        mc.__aenter__ = AsyncMock(return_value=mc); mc.__aexit__ = AsyncMock(return_value=False)
+        with patch("backend.ingestion.url_fetcher.httpx.AsyncClient", return_value=mc):
+            r = await _fetch_mast_bill("https://mast.co.il/bill-viewer/abc", str(tmp_path), 5)
+        assert r is None
+
+    async def test_unsafe_pdflink_returns_none(self, tmp_path):
+        api = {"stubExtentionList": [{"pdfLink": "https://169.254.169.254/x.pdf"}]}
+        with patch("backend.ingestion.url_fetcher.httpx.AsyncClient", return_value=_mast_client(api)), \
+             patch("backend.ingestion.url_fetcher._is_safe_url", return_value=False):
+            r = await _fetch_mast_bill("https://mast.co.il/bill-viewer/abc", str(tmp_path), 5)
+        assert r is None
+
+    async def test_fetch_url_routes_mast_to_api(self, tmp_path):
+        api = {"stubExtentionList": [{"pdfLink": "https://sabillsprod.blob.core.windows.net/x.pdf"}]}
+        with patch("backend.ingestion.url_fetcher.httpx.AsyncClient", return_value=_mast_client(api)), \
+             patch("backend.ingestion.url_fetcher._is_safe_url", return_value=True):
+            r = await fetch_url("https://mast.co.il/bill-viewer/abc", str(tmp_path))
+        assert r is not None and r.method == "mast_api"
+
+    async def test_pdf_fetch_error_returns_none(self, tmp_path):
+        # API resolves a pdfLink, but the blob GET 500s -> None (not a crash).
+        api = {"stubExtentionList": [{"pdfLink": "https://sabillsprod.blob.core.windows.net/x.pdf"}]}
+        with patch("backend.ingestion.url_fetcher.httpx.AsyncClient", return_value=_mast_client(api, pdf_status=500)):
+            r = await _fetch_mast_bill("https://mast.co.il/bill-viewer/abc", str(tmp_path), 5)
+        assert r is None
+
+    async def test_api_non_dict_json_returns_none(self, tmp_path):
+        # Valid JSON but wrong shape (a top-level array) must degrade to None,
+        # NOT raise AttributeError up through the unguarded gmail caller.
+        with patch("backend.ingestion.url_fetcher.httpx.AsyncClient", return_value=_mast_client([])):
+            r = await _fetch_mast_bill("https://mast.co.il/bill-viewer/abc", str(tmp_path), 5)
+        assert r is None
+
+    async def test_api_malformed_json_returns_none(self, tmp_path):
+        # Non-JSON body with a JSON content-type -> resp.json() raises -> None.
+        async def fake_get(url, **kw):
+            return _make_response(200, b"<not json>", "application/json")
+        mc = AsyncMock(); mc.get = fake_get
+        mc.__aenter__ = AsyncMock(return_value=mc); mc.__aexit__ = AsyncMock(return_value=False)
+        with patch("backend.ingestion.url_fetcher.httpx.AsyncClient", return_value=mc):
+            r = await _fetch_mast_bill("https://mast.co.il/bill-viewer/abc", str(tmp_path), 5)
+        assert r is None


### PR DESCRIPTION
## Summary

Fixes #32 — email/Telegram-ingested bills whose PDF sits behind a JS download button or a hostile SPA viewer (`מועצה מקומית מבשרת ציון` via `mast.co.il/bill-viewer`) were saved as a 1-page render of the *viewer page* (`page.pdf()` shell) and filed as `processed` — a silent wrong-file bug. Doc 266 (email) was a 1-page/300KB shell; the real bill (doc 185, hand-submitted) is 2 pages/680KB.

Three layers, weakest to strongest:

**Safety net (kills the silent failure).** `page.pdf()` shell captures now set `FetchResult.page_capture` and route to `needs_review` in **both** the gmail and telegram callers (via a shared `PAGE_CAPTURE_NOTE`), so a capture failure is never filed as the real bill.

**Generic button-click capture.** `_try_click_download` clicks the single best download control — a multilingual/Hebrew keyword net (`הורדה`…), a hard pay/submit/delete denylist — inside `page.expect_download`, with the `application/pdf` response listener kept alive across the click (dual capture: attachment download OR inline PDF response).

**mast.co.il site handler.** `_fetch_mast_bill` resolves the bill deterministically via the mast JSON API (`GetStubsByGuidForPresentingStubs?guid=…` → `pdfLink`) with no browser at all — the viewer's shadow-DOM + iframe + reCAPTCHA make DOM scraping infeasible, but the API the SPA itself calls is open. **Verified live against the reported bill: real 2-page / 680KB PDF.**

Commits: `4c9c853` (fix + tests), `ade5f15` (plan + eng-review report).

## Test Coverage

```
_mast_guid gate .................... ★★★ 5/5
_fetch_mast_bill ................... ★★★ (happy, multistub, no-pdflink, unsafe,
                                     API 4xx/5xx, API json-shape/malformed, pdf-fetch error)
_try_click_download ............... ★★★ (heb/eng/aria, rank+denylist, blob safe/unsafe-origin,
                                     SSRF http reject, oversize, click-raises, timeout, inline, hidden-skip)
_playwright_fetch wiring .......... ★★★ (click-success returned; page.pdf fallback→page_capture;
                                     auth_wall NOT page_capture)
gmail / telegram downgrade ........ ★★★ 3/3 each
```
Tests: 312 → 333 (+21 new). Full suite **333 passed**.

## Pre-Landing Review

Ran the review army (security + maintainability + adversarial red-team + coverage). **12 findings — all auto-fixed, then re-verified green.**

**CRITICAL (3, multi-specialist confirmed):**
- `download.path()` was unbounded → a stalled download body would hang the single-process ingestion queue forever. Fixed: `asyncio.wait_for`.
- Size cap was post-hoc (`read_bytes()` before the check) → multi-GB download OOMs the NAS. Fixed: `os.stat` size check on disk before reading.
- mast JSON parsed outside the try/except → a valid-but-unexpected shape raised `AttributeError` that propagated through the unguarded gmail caller and **aborted the whole email batch**. Fixed: `isinstance` guard.

**Hardening (informational):** `follow_redirects=False` on mast fetches (SSRF-via-redirect); log host, not the SAS-bearing pdfLink; blob/data downloads gated on page origin; capped retained `pdf_responses`; DRY'd the needs_review note; named the timeout constants.

## Design Review
No frontend files changed — design review skipped.

## Eval Results
No prompt-related files changed — evals skipped.

## Plan Completion
Plan: `docs/plans/2026-09-02-issue32-email-button-download.md` (eng-review CLEAR, 6 findings folded). T1–T5 all delivered: button-click capture, `page_capture` flag, both-caller downgrades, 21 tests, and the live verification (which surfaced the SPA/reCAPTCHA wall → the mast API handler was added).

## TODOS
No TODO items completed in this PR.

## Documentation

No documentation changes required. Issue #32 is an internal ingestion fix (`url_fetcher.py`, `gmail.py`, `telegram.py`): captures the real PDF for button-gated/SPA bill viewers (mast.co.il JSON-API handler) and routes uncapturable viewer-shell captures to `needs_review`. No new env vars, config keys, API routes, or user-facing UI, so README/CLAUDE.md/TODOS/docs are all still accurate.

### Documentation Debt
- ⚠️ Email/Telegram URL-link bill fetching (built in #27, extended here) has zero coverage in README's Gmail/ingestion section — it documents only attachment + HTML-email ingestion. Reference/how-to gap. Pre-existing, out of this change's docs-sync scope; consider a `docs-debt` label.

## Test plan
- [x] Full pytest suite passes (333 tests, 0 failures)
- [x] Live capture verified against the real mast bill (2 pages / 680KB via `mast_api`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
