### PR TITLE
fix(scanner): size live detection from a fixed 800px edge, not a fraction of video

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,8 @@ frontend/src/           # React SPA
   lib/api.ts            # Fetch wrapper with auth handling
   lib/pdf-builder.ts    # Scanned pages -> PDF (page size from pixels, see Gotchas)
   lib/scanner/          # Detection + geometry: canvas-utils, geometry, coords,
-                        # smoother, classical-detector, ml-detector
+                        # smoother, classical-detector, ml-detector,
+                        # detection-size (the shared detection resolution)
   lib/**/*.test.ts      # vitest suite (pure logic, node env)
   contexts/             # AuthContext
   pages/                # Page components
@@ -85,7 +86,7 @@ cd .claude/skills/gstack && ./setup
 - `test_normalize.py::test_html_to_pdf` is skipped on Windows (weasyprint requires GTK/Pango native libs). Passes in Docker/Linux.
 - Backend API tests use `create_app(data_dir, run_background=False)` with `TestClient`.
 
-**Frontend (vitest):** `cd frontend && npm test` (9 files, 115 tests).
+**Frontend (vitest):** `cd frontend && npm test` (11 files, 160 tests).
 
 - Config is `frontend/vitest.config.ts`: `environment: "node"`, **no jsdom**, `include: ["src/**/*.test.ts"]`. Tests live next to the module they cover (`src/lib/scanner/geometry.test.ts`, ...).
 - Pure logic only, on purpose. `ImageData`, `HTMLCanvasElement`, and `drawImage` do not exist in Node, so anything touching a canvas (`src/lib/scanner/canvas-utils.ts`) is deliberately untested — covering it means jsdom plus the native `canvas` package, which drags cairo/pango build deps into the Docker image.
@@ -114,6 +115,8 @@ cd .claude/skills/gstack && ./setup
 - The `frontend/dist/` directory persists after builds. If present, the static files mount activates. Always set `RECEIPTORY_DEV=1` when running backend + Vite dev server together.
 - SQLite `executescript()` auto-commits and can interfere with transaction isolation. The migration runner uses a dedicated connection that's closed after migrations.
 - **Scanner DPI is coupled across the stack.** `TARGET_DPI` in `frontend/src/lib/pdf-builder.ts` (200) sizes each scanned PDF page in millimetres from its own pixel dimensions; `page_render_dpi` in `backend/config.py` (200) rasters that PDF back to pixels for the LLM. The round trip is 1:1 only while the two are equal — change one without the other and capture resolution is silently thrown away before the model ever sees it. Both files carry reciprocal comments.
+- **Detection resolution is a fixed edge, never a fraction of the video.** `DETECTION_MAX_EDGE` in `frontend/src/lib/scanner/detection-size.ts` (800) sizes every detection frame — the live viewfinder loop, the review-entry re-detect, and the Lab's eval. It used to be `videoWidth * 0.4`, which was tuned at 1080p (768px); raising the camera ladder to 4K silently made it 1536px, and the live box went jumpy on-device with no error anywhere. Scanic discards everything above 800 itself (`maxProcessingDimension`, kept equal but deliberately not derived), so the extra pixels only ever cost `preprocess()` time. `detectionSizeFor` never upscales — a fixed target is not monotonically a downscale the way a fraction was.
+- **`staleMs` must exceed one detection cycle.** `TemporalSmoother`'s `staleMs` (250ms) versus `MIN_DETECT_INTERVAL_MS` (80ms) plus detect latency. Breach it and the live box goes jumpy — but *only* jumpy: `reset()` empties the buffer, so the next `push` skips the warmup drift gate and the box returns within one cycle. A box that is absent for seconds means `corners: null` repeatedly, which is a detector or hard-reject problem instead. Both files carry reciprocal comments.
 - jsPDF **sorts** a `format: [w, h]` array and then uses `orientation` to decide which value is the page width, so `{orientation: "portrait", format: [300, 100]}` yields a 100x300 page and the image is silently clipped. Derive orientation from the dimensions instead: `w > h ? "landscape" : "portrait"`.
 
 ## gstack

--- a/TODOS.md
+++ b/TODOS.md
@@ -300,6 +300,57 @@ Deferred items captured during planning and review. Organized by component, sort
 **Depends on:** None
 **Depends on:** ML detection is shipped and live (Phase 1 of the ML detector plan). Only worth building if a non-WebGPU device enters the picture, or the S26 WASM fallback benchmark is bad
 
+### Manual bounding-box specification in the review screen
+
+**What:** A "Set corners manually" button in `CaptureReview` that enters a mode where four taps place top-left, top-right, bottom-right and bottom-left directly. Plus hint text shown when the displayed quad came from the no-detection fallback rather than a real detection.
+
+**Why:** When detection returns nothing the user gets `insetCorners(raw.width, raw.height)` — a 10% inset quad (`CaptureReview.tsx:112,:166`) — and the only available move is dragging its four corners inward. `handlePointerDown:206` returns early for any tap further than `HANDLE_HIT_R_PX` (44 screen px) from an existing corner, so corners can be nudged but never placed. For a small receipt in a large frame that is four long drags from the frame edges, and nothing on screen says the box is interactive at all. Owner raised it 2026-09-05: "in cases in which bbox cannot be found automatically, user is unable to set the box."
+
+**Design decided 2026-09-05** (owner chose option C of three):
+- Tap-to-place mode behind an explicit button, NOT tap-anywhere-moves-nearest and NOT drag-to-draw.
+- Rejected tap-anywhere-moves-nearest: it is a two-line change but reverses the deliberate non-destructive-tap design at `handlePointerUp:280-288`, so a stray tap on an already-good box would move a corner and burn a full-resolution re-warp.
+- Rejected drag-to-draw: a dragged rectangle is axis-aligned, and the four-corner quad exists precisely so an angled receipt is perspective-corrected on warp. It would need corner-dragging afterwards anyway — two gestures instead of one.
+
+**Pros:**
+- The button is the affordance the screen currently lacks
+- Preserves arbitrary quads, so perspective correction survives
+- Taps stay non-destructive outside the mode
+
+**Cons:**
+- A modal interaction mode needs its own escape/cancel path and an in-progress indicator (which of the four corners is next)
+- More UI in a screen the design already wanted kept simple
+
+**Context:**
+- Start: `frontend/src/components/scanner/CaptureReview.tsx` — the mode gates `handlePointerDown`; `onCornersCommit(orderQuadByAngle(...))` already exists and should be reused for the commit
+- Note `orderQuadByAngle` relabels corners by angle around the centroid, so tap ORDER need not be trusted — a user who taps them out of order still gets a sane quad
+- May become rarer once E3 (the scanner-miss vs hard-reject split, shipped 2026-09-05) shows whether hard rejects are discarding good quads, but is worth having as a safety net regardless
+
+**Effort:** M
+**Priority:** P1
+**Depends on:** None. Own branch — it is review-screen UI and unrelated to the detection-resolution work.
+
+### Reduce per-detection allocation in `preprocess()`
+
+**What:** Reuse module-scoped scratch buffers and canvases (keyed on frame dimensions) instead of allocating fresh ones every detection. Today each `preprocess()` call allocates two canvases in `canvasBlur` (`classical-detector.ts:172,178`), a third in `imageDataToCanvas` (`:52`), and five full-frame `Uint8ClampedArray`s across `grayscaleAsRgba`, `shadowNormalize`, `saturationMask` and `composeWeighted`.
+
+**Why:** At the `MIN_DETECT_INTERVAL_MS = 80` floor that is roughly 37 canvas allocations per second. A multi-hundred-millisecond GC pause produces exactly the symptom under investigation on 2026-09-05 — a bounding box that vanishes for a visible stretch — whereas a merely slow detector only produces a flicker (after `TemporalSmoother.reset()` the buffer is empty, so the next `push` skips the drift gate and the box returns within one cycle, `smoother.ts:81`). Shrinking the detection frame to 800px cuts the bytes per allocation 4x but leaves the allocation *rate* unchanged.
+
+**Pros:**
+- Removes a plausible mechanism for sustained box absence that the resolution fix does not address
+- Scratch-buffer reuse is mechanical and unit-testable
+
+**Cons:**
+- Introduces mutable module state into a detector that is currently pure per call
+- May be entirely moot — see Depends on
+
+**Context:**
+- Source: outside voice, `/plan-eng-review` 2026-09-05, branch `fix/scanner-detection-resolution`
+- Start: `frontend/src/lib/scanner/classical-detector.ts:97-156`
+
+**Effort:** S
+**Priority:** P2
+**Depends on:** The Lab A/B of `{shadowNorm: false, saturationPrior: false}` over the stored corpus. If preprocessing does not improve median IoU, **delete it rather than optimise it** — Scanic grayscales and downsamples the result anyway (`prepareScaleAndGrayscale`), and this TODO evaporates.
+
 ### Web Worker for live detection
 
 **What:** Move the detection pipeline (preprocess + inference + parse) to a Web Worker using OffscreenCanvas + transferable ImageData, so the main thread never blocks during live detection.

--- a/TODOS.md
+++ b/TODOS.md
@@ -300,6 +300,29 @@ Deferred items captured during planning and review. Organized by component, sort
 **Depends on:** None
 **Depends on:** ML detection is shipped and live (Phase 1 of the ML detector plan). Only worth building if a non-WebGPU device enters the picture, or the S26 WASM fallback benchmark is bad
 
+### Remove the E2 diagnostics strip from the scanner viewfinder
+
+**What:** Delete the `REQ 4K` / `REQ 1080p` toggle and the `granted / video / detect / cam` readout from `CameraViewfinder.tsx`, plus the `Diagnostics` interface, the `capture4k` state, the `LADDER_CONTROL_1080P` constant and the `lastVideoW`/`lastVideoH` tracking that feeds it. Roughly 45 lines.
+
+**Why:** It is experiment scaffolding (T1/T2, the "did 4K break detection?" control) shipped unconditionally into the production scanner UI. It earns its place while the E2/E3/E4 verdicts are still being gathered — the owner is the only user and also the tester — but nothing in the change that added it schedules its removal, so it becomes permanent UI by default. Flagged independently by two reviewers on 2026-09-05.
+
+**Pros:**
+- Returns the viewfinder to a clean capture surface
+- Removes two semi-transparent overlays from a screen whose job is framing a receipt
+
+**Cons:**
+- The `cam` deviceId line is the only place a lens swap is visible; losing it means re-adding instrumentation if the question returns
+- A dev-only gate (`import.meta.env.DEV`) is NOT a substitute: the on-device tests run against the deployed production build, so gating would remove it from exactly the build that needs it
+
+**Context:**
+- Source: `/review` of `fix/scanner-detection-resolution`, 2026-09-05 (simplification + maintainability lenses)
+- Start: `frontend/src/components/scanner/CameraViewfinder.tsx`
+- Note the toggle can no longer reproduce pre-T6 detection: with a fixed `DETECTION_MAX_EDGE`, 3840x2160 and 1920x1080 both detect at 800x450. Its remaining value is isolating capture and lens effects, not detection cost.
+
+**Effort:** S
+**Priority:** P2
+**Depends on:** E2, E3 and E4 verdicts landing. Do not remove before then.
+
 ### Manual bounding-box specification in the review screen
 
 **What:** A "Set corners manually" button in `CaptureReview` that enters a mode where four taps place top-left, top-right, bottom-right and bottom-left directly. Plus hint text shown when the displayed quad came from the no-detection fallback rather than a real detection.

--- a/frontend/src/components/scanner/CameraViewfinder.tsx
+++ b/frontend/src/components/scanner/CameraViewfinder.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useCamera } from "@/lib/useCamera";
 import type { Detector, Quad } from "@/lib/scanner/detector";
 import { TemporalSmoother } from "@/lib/scanner/smoother";
+import { detectionSizeFor } from "@/lib/scanner/detection-size";
 
 interface CameraViewfinderProps {
   detector: Detector;
@@ -19,13 +20,63 @@ interface CameraViewfinderProps {
   onCapture: (imageData: ImageData, emaCorners: Quad | null, detectionScale: number) => void;
 }
 
-/** Target detection resolution as a fraction of the video dimensions. */
-const DETECTION_SCALE = 0.4;
+/*
+ * Detection is sized by `detectionSizeFor(videoW, videoH, DETECTION_MAX_EDGE)`.
+ *
+ * It used to be a FRACTION of the video — `videoWidth * 0.4` — which was tuned
+ * when the preview was 1080p: 0.4 x 1920 = 768px, matching the ~800px contract
+ * in `detector.ts`. When the camera ladder was raised to 3840x2160 that fraction
+ * silently became 1536px, four times the pixels every ClassicalParams default
+ * was tuned against, and every one above 800 is discarded by scanic anyway —
+ * but only after `preprocess()` has paid five per-pixel JS passes on it.
+ *
+ * Verified on-device 2026-09-05: with the request capped at 1080p the box is
+ * measurably more stable than at 4K, same receipt, same light. A fixed edge
+ * gives the scanner that stability while `handleCapture` keeps grabbing the full
+ * video frame, so the final extract still gets every 4K pixel.
+ */
+
+/**
+ * The control arm for the "did 4K break detection?" experiment (E2).
+ *
+ * `useCamera()` with no argument requests 3840x2160 and walks the ladder down.
+ * This forces the ladder to start at 1080p instead, which is where the detector
+ * parameters were originally tuned. The toggle exists because the two arms have
+ * to be compared against the SAME receipt under the SAME light — two builds
+ * shot minutes apart is not a control, and the on-device verdict is the only
+ * verdict this subsystem accepts.
+ *
+ * On many Android devices the 4K rung also selects a different physical lens,
+ * with a narrower field of view and a longer minimum focus distance. A lens that
+ * cannot focus at receipt distance produces frames with no contour to find,
+ * which looks exactly like a broken detector. The `cam` line in the diagnostics
+ * strip reports `deviceId`, so a lens swap between the two arms is visible
+ * rather than inferred.
+ *
+ * Module scope, not an inline literal: `useCamera` destructures to primitives
+ * precisely so a fresh object identity per render cannot restart getUserMedia,
+ * but there is no reason to lean on that.
+ */
+const LADDER_CONTROL_1080P = { width: 1920, height: 1080 };
+
+/** What the detection loop last actually ran on. Diagnostics only. */
+interface Diagnostics {
+  videoW: number;
+  videoH: number;
+  detW: number;
+  detH: number;
+}
 /**
  * Floor on the gap between detections. `requestVideoFrameCallback` fires once
  * per video frame (~30-60Hz); the re-entrancy guard alone would run a ~50ms
  * main-thread detection roughly 5x more often than the old `rAF % 5` cadence
  * and make the preview worse, not better.
+ *
+ * COUPLED CONSTANT — this plus `Detector.detect()` latency is one detection
+ * cycle, and `TemporalSmoother`'s `staleMs` (smoother.ts, 250ms) must exceed it
+ * or the lock is released between results and the box goes jumpy. Detection is
+ * capped at `DETECTION_MAX_EDGE` to hold detect latency down. Raise one, check
+ * the other.
  */
 const MIN_DETECT_INTERVAL_MS = 80;
 
@@ -34,7 +85,20 @@ export default function CameraViewfinder({
   detectorParams,
   onCapture,
 }: CameraViewfinderProps) {
-  const { videoRef, error, ready, retry } = useCamera();
+  /**
+   * E2's control switch. Defaults to true, i.e. the shipped 4K behaviour —
+   * the experiment must not change what the scanner does by default.
+   */
+  const [capture4k, setCapture4k] = useState(true);
+  const { videoRef, error, ready, retry, settings } = useCamera(
+    capture4k ? undefined : LADDER_CONTROL_1080P,
+  );
+  /**
+   * Written only when the detection space actually changes, which is the same
+   * moment the offscreen canvas is resized — once per camera acquisition or
+   * orientation change, never per frame.
+   */
+  const [diagnostics, setDiagnostics] = useState<Diagnostics | null>(null);
   const svgRef = useRef<SVGSVGElement>(null);
   const overlayGroupRef = useRef<SVGGElement>(null);
   const polygonRef = useRef<SVGPolygonElement>(null);
@@ -44,7 +108,14 @@ export default function CameraViewfinder({
    * updated imperatively so a detection never costs a React render.
    */
   const cornersRef = useRef<Quad | null>(null);
-  const detectionScaleRef = useRef(DETECTION_SCALE);
+  /**
+   * Seeded at 1 (identity), not at a guessed ratio: until the first detection
+   * has run there is no video size to derive one from, and a stale guess used
+   * by a capture that lands first is a silently wrong crop. `handleCapture`
+   * only ever divides by this alongside corners that the same detection
+   * produced, so identity is the honest starting value.
+   */
+  const detectionScaleRef = useRef(1);
   const [documentDetected, setDocumentDetected] = useState(false);
   const [detectorError, setDetectorError] = useState<string | null>(null);
   const detecting = useRef(false);
@@ -142,8 +213,8 @@ export default function CameraViewfinder({
         lastDetectAt = now;
         detecting.current = true;
 
-        const w = Math.max(1, Math.round(video.videoWidth * DETECTION_SCALE));
-        const h = Math.max(1, Math.round(video.videoHeight * DETECTION_SCALE));
+        const size = detectionSizeFor(video.videoWidth, video.videoHeight);
+        const { w, h } = size;
         if (offscreen.width !== w || offscreen.height !== h) {
           offscreen.width = w;
           offscreen.height = h;
@@ -155,10 +226,17 @@ export default function CameraViewfinder({
           smoother.reset();
           cornersRef.current = null;
           setDocumentDetected(false);
+          // Same trigger, so this costs one render per resolution change, not
+          // one per detection.
+          setDiagnostics({ videoW: video.videoWidth, videoH: video.videoHeight, detW: w, detH: h });
         }
         detW = w;
         detH = h;
-        detectionScaleRef.current = w / video.videoWidth;
+        // The ratio `detectionSizeFor` actually applied, not one re-derived from
+        // `w / video.videoWidth`. Those differ by up to half a pixel of rounding
+        // and it is the same one-ratio-two-derivations shape that produced the
+        // original overlay bug. Still never a constant.
+        detectionScaleRef.current = size.scale;
 
         ctx.drawImage(video, 0, 0, w, h);
         const imageData = ctx.getImageData(0, 0, w, h);
@@ -291,6 +369,42 @@ export default function CameraViewfinder({
           ))}
         </g>
       </svg>
+
+      {/*
+        Diagnostics strip (T1/T2). Reports what the camera actually granted
+        versus what was asked for, and what the detector actually ran on.
+        Every scanner verdict before 2026-09-05 was given without any of these
+        numbers visible, which is how "detection is broken" and "the ladder
+        negotiated a different lens" stayed indistinguishable for months.
+      */}
+      <div className="absolute top-2 left-2 right-2 flex items-start gap-2 pointer-events-none">
+        <button
+          type="button"
+          onClick={() => setCapture4k((v) => !v)}
+          className="pointer-events-auto shrink-0 px-2 py-1 rounded-md bg-black/60 text-white text-[10px] font-bold tracking-wider backdrop-blur-sm active:bg-black/80"
+        >
+          {capture4k ? "REQ 4K" : "REQ 1080p"}
+        </button>
+        <div className="flex-1 min-w-0 px-2 py-1 rounded-md bg-black/50 text-white/70 text-[10px] font-mono leading-tight backdrop-blur-sm">
+          {/*
+            `granted` is track.getSettings(); `video` is the decoded frame size.
+            They disagree whenever Android hands back a landscape-oriented track
+            under a portrait UI, and detection follows `video`, not `granted`.
+          */}
+          <div>
+            granted {settings?.width ?? "?"}x{settings?.height ?? "?"}
+            {settings?.frameRate ? ` @${Math.round(settings.frameRate)}fps` : ""}
+          </div>
+          <div>
+            video {diagnostics ? `${diagnostics.videoW}x${diagnostics.videoH}` : "?"}
+            {" · detect "}
+            {diagnostics ? `${diagnostics.detW}x${diagnostics.detH}` : "?"}
+          </div>
+          {/* The lens discriminator: a different id across the two arms means
+              the ladder swapped cameras, not just resolutions. */}
+          <div className="truncate">cam {settings?.deviceId?.slice(0, 12) ?? "?"}</div>
+        </div>
+      </div>
 
       {!ready && (
         <div className="absolute inset-0 flex items-center justify-center bg-black">

--- a/frontend/src/components/scanner/CameraViewfinder.tsx
+++ b/frontend/src/components/scanner/CameraViewfinder.tsx
@@ -141,6 +141,9 @@ export default function CameraViewfinder({
     let lastDetectAt = 0;
     let handle = 0;
     let cancelled = false;
+    /** Last video dimensions published to the diagnostics strip. */
+    let lastVideoW = 0;
+    let lastVideoH = 0;
 
     const useRvfc = typeof video.requestVideoFrameCallback === "function";
 
@@ -215,6 +218,19 @@ export default function CameraViewfinder({
 
         const size = detectionSizeFor(video.videoWidth, video.videoHeight);
         const { w, h } = size;
+
+        // Refresh the strip whenever the VIDEO size changes, not only when the
+        // detection size does. With a fixed max edge those are no longer the
+        // same event: 3840x2160 and 1920x1080 both detect at 800x450, so keying
+        // the strip on the detection size alone would leave a mid-stream track
+        // renegotiation showing a stale `video` line next to a fresh `granted`
+        // line — two contradictory numbers in the readout built to settle
+        // exactly that question.
+        if (lastVideoW !== video.videoWidth || lastVideoH !== video.videoHeight) {
+          lastVideoW = video.videoWidth;
+          lastVideoH = video.videoHeight;
+          setDiagnostics({ videoW: lastVideoW, videoH: lastVideoH, detW: w, detH: h });
+        }
         if (offscreen.width !== w || offscreen.height !== h) {
           offscreen.width = w;
           offscreen.height = h;
@@ -226,9 +242,6 @@ export default function CameraViewfinder({
           smoother.reset();
           cornersRef.current = null;
           setDocumentDetected(false);
-          // Same trigger, so this costs one render per resolution change, not
-          // one per detection.
-          setDiagnostics({ videoW: video.videoWidth, videoH: video.videoHeight, detW: w, detH: h });
         }
         detW = w;
         detH = h;
@@ -381,7 +394,7 @@ export default function CameraViewfinder({
         <button
           type="button"
           onClick={() => setCapture4k((v) => !v)}
-          className="pointer-events-auto shrink-0 px-2 py-1 rounded-md bg-black/60 text-white text-[10px] font-bold tracking-wider backdrop-blur-sm active:bg-black/80"
+          className="pointer-events-auto shrink-0 px-2 py-1 rounded-md bg-black/75 text-white text-[10px] font-bold tracking-wider active:bg-black/90"
         >
           {capture4k ? "REQ 4K" : "REQ 1080p"}
         </button>

--- a/frontend/src/lib/opencv-loader.ts
+++ b/frontend/src/lib/opencv-loader.ts
@@ -25,6 +25,12 @@ export async function initScanner(): Promise<void> {
   if (initPromise) return initPromise;
 
   const p = (async () => {
+    // Kept EQUAL to DETECTION_MAX_EDGE (detection-size.ts), deliberately not
+    // imported from it. Scanic downsamples anything larger to this before it
+    // looks for a contour (prepareScaleAndGrayscale), so matching the two means
+    // scanic does not resample a frame we already sized. But this bound belongs
+    // to scanic: a scanic upgrade that changes its own default should not be
+    // silently overridden by ours. If you change one, look at the other.
     const s = new Scanner({ maxProcessingDimension: 800, output: "canvas" });
     await s.initialize();
     scanner = s;

--- a/frontend/src/lib/opencv-loader.ts
+++ b/frontend/src/lib/opencv-loader.ts
@@ -51,44 +51,31 @@ export function getScanner(): Scanner {
   return scanner;
 }
 
-/** Detect document corners from a (downscaled) video frame. */
-export async function detectCorners(imageData: ImageData): Promise<any> {
-  const s = getScanner();
-  const canvas = imageDataToCanvas(imageData);
-  const result = await s.scan(canvas, { mode: "detect" });
-  if (result.success && result.corners) {
-    return result.corners;
-  }
-  return null;
-}
-
 /**
  * Extract the document from a full-resolution capture.
- * Corners come from detectCorners() which ran on a 0.4x scaled frame,
- * so they need to be scaled up to match the full-res imageData.
+ *
+ * `corners` are in the SAME pixel space as `imageData` — raw-frame pixels.
+ *
+ * This used to take a `detectionScale` parameter defaulting to 0.4, back when
+ * corners arrived in detection space and had to be scaled up here. Callers now
+ * convert at the detector boundary using the ratio `detectionSizeFor` actually
+ * applied, so by the time corners reach this function there is nothing left to
+ * scale. The default was the dangerous part: it silently multiplied
+ * already-converted corners by 2.5, and the one caller had to pass `1`
+ * explicitly with a comment explaining why. Both are gone.
  */
 export async function extractAndEnhance(
   imageData: ImageData,
   corners: any | null,
-  detectionScale: number = 0.4,
 ): Promise<{ original: HTMLCanvasElement; enhanced: HTMLCanvasElement }> {
   const s = getScanner();
   const fullCanvas = imageDataToCanvas(imageData);
 
   let outputCanvas: HTMLCanvasElement | null = null;
 
-  // Scale corners from detection resolution to full resolution
   if (corners) {
-    const scale = 1 / detectionScale;
-    const scaledCorners = {
-      topLeft: { x: corners.topLeft.x * scale, y: corners.topLeft.y * scale },
-      topRight: { x: corners.topRight.x * scale, y: corners.topRight.y * scale },
-      bottomRight: { x: corners.bottomRight.x * scale, y: corners.bottomRight.y * scale },
-      bottomLeft: { x: corners.bottomLeft.x * scale, y: corners.bottomLeft.y * scale },
-    };
-
     try {
-      const result = await s.extract(fullCanvas, scaledCorners, { output: "canvas" });
+      const result = await s.extract(fullCanvas, corners, { output: "canvas" });
       const out = result.output as HTMLCanvasElement | undefined;
       // BOTH dimensions. A near-degenerate quad yields an N x 0 canvas, which
       // passed a width-only check, flowed on as a valid crop, enabled Submit,

--- a/frontend/src/lib/scanner/canvas-utils.ts
+++ b/frontend/src/lib/scanner/canvas-utils.ts
@@ -7,7 +7,12 @@
  *
  * Not unit-tested on purpose: `ImageData` and `drawImage` do not exist in Node,
  * and these are thin, branchless wrappers around the browser's own scaling.
+ * Anything here with real arithmetic in it belongs in a DOM-free module that
+ * CAN be tested — `downscaleImageData` delegates its sizing to
+ * `detection-size.ts` for exactly that reason.
  */
+
+import { detectionSizeFor } from "./detection-size";
 
 /** Wrap an ImageData in a canvas of the same dimensions. */
 export function imageDataToCanvas(image: ImageData): HTMLCanvasElement {
@@ -39,16 +44,14 @@ export function downscaleImageData(
   image: ImageData,
   maxEdge: number,
 ): { data: ImageData; scale: number } {
-  const longest = Math.max(image.width, image.height);
-  if (!(maxEdge > 0) || longest <= maxEdge) return { data: image, scale: 1 };
-
-  // One uniform ratio for both axes. The per-axis ratios (w/image.width,
-  // h/image.height) differ from it by at most half a pixel of rounding; using
-  // the uniform ratio keeps the mapping isotropic, which is what the aspect
-  // preservation promises.
-  const scale = maxEdge / longest;
-  const w = Math.max(1, Math.round(image.width * scale));
-  const h = Math.max(1, Math.round(image.height * scale));
+  // The size decision — including the no-upscale clamp that gives `scale === 1`
+  // its meaning — lives in `detection-size.ts` and is unit-tested there. This
+  // function owns only the canvas work. Keeping the arithmetic in one place is
+  // the point: the live viewfinder loop sizes its frame from the same helper,
+  // and two copies of "how big should the detection frame be" is exactly the
+  // duplication that let the 4K raise silently quadruple it.
+  const { w, h, scale } = detectionSizeFor(image.width, image.height, maxEdge);
+  if (scale === 1) return { data: image, scale: 1 };
 
   const src = imageDataToCanvas(image);
   const out = document.createElement("canvas");

--- a/frontend/src/lib/scanner/canvas-utils.ts
+++ b/frontend/src/lib/scanner/canvas-utils.ts
@@ -53,14 +53,52 @@ export function downscaleImageData(
   const { w, h, scale } = detectionSizeFor(image.width, image.height, maxEdge);
   if (scale === 1) return { data: image, scale: 1 };
 
-  const src = imageDataToCanvas(image);
-  const out = document.createElement("canvas");
-  out.width = w;
-  out.height = h;
+  const src = scratch(0, image.width, image.height);
+  src.getContext("2d")!.putImageData(image, 0, 0);
+
+  const out = scratch(1, w, h);
   const ctx = out.getContext("2d", { willReadFrequently: true })!;
   ctx.drawImage(src, 0, 0, w, h);
 
   return { data: ctx.getImageData(0, 0, w, h), scale };
+}
+
+/**
+ * Two reusable canvases, resized in place rather than reallocated per call.
+ *
+ * This function is called once per frame by the Lab's `runEval` loop, which
+ * walks the whole corpus without yielding. Canvas backing stores are external
+ * memory, so a GC with no heap-pressure signal happily lets dozens of them pile
+ * up — the "eval dies partway through the corpus on a phone" shape. The live
+ * viewfinder loop already avoids this by creating its offscreen canvas once
+ * (`CameraViewfinder`); this brings the shared helper in line.
+ *
+ * Safe because `downscaleImageData` is fully synchronous: two calls can never
+ * interleave and share a scratch buffer mid-use. Anything that makes this
+ * function async must give up the scratch canvases.
+ *
+ * NOT used by `imageDataToCanvas` — its callers keep the canvas they are handed
+ * (scanic's `extract` holds one across an await), so those must stay fresh.
+ */
+const scratchCanvases: (HTMLCanvasElement | null)[] = [null, null];
+
+function scratch(slot: 0 | 1, w: number, h: number): HTMLCanvasElement {
+  let c = scratchCanvases[slot];
+  if (!c) {
+    c = document.createElement("canvas");
+    scratchCanvases[slot] = c;
+  }
+  if (c.width !== w || c.height !== h) {
+    // Assigning either dimension clears the canvas, so this doubles as the wipe.
+    c.width = w;
+    c.height = h;
+  } else {
+    // Same size as last time: nothing cleared it, so clear it explicitly. The
+    // callers below fully overwrite the surface, but relying on that silently
+    // couples this helper to their compositing mode.
+    c.getContext("2d")!.clearRect(0, 0, w, h);
+  }
+  return c;
 }
 
 /**

--- a/frontend/src/lib/scanner/classical-detector.test.ts
+++ b/frontend/src/lib/scanner/classical-detector.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect } from "vitest";
-import { classifyScanResult, scanThrowMessage, toQuad } from "./classical-detector";
+import {
+  CLASSICAL_DEFAULTS,
+  classifyScanResult,
+  firstHardReject,
+  scanThrowMessage,
+  toQuad,
+  type Metrics,
+} from "./classical-detector";
 
 /**
  * The silent-failure suite.
@@ -111,5 +118,72 @@ describe("toQuad — the NaN guard", () => {
   it("returns null for null/undefined input", () => {
     expect(toQuad(null)).toBeNull();
     expect(toQuad(undefined)).toBeNull();
+  });
+});
+
+/**
+ * The hard rejects — the gates that turn "scanic found a quad" into
+ * `corners: null` with no error, which the viewfinder renders identically to an
+ * empty table. Zero coverage existed before 2026-09-05, on the branch that
+ * changed them.
+ *
+ * `firstHardReject` takes `Metrics`, not `ImageData`, so it is pure and needs no
+ * DOM — the whole reason it was extracted.
+ */
+describe("firstHardReject — which gate threw the quad away", () => {
+  /** A quad that passes everything, so each test can spoil exactly one field. */
+  const passing: Metrics = {
+    area: 100_000,
+    areaFraction: 0.4,
+    convexity: 1,
+    aspect: 2,
+    minAngle: 85,
+    maxAngle: 95,
+    uniformity: 0.9,
+    textDensity: 0.1,
+    score: () => 0.8,
+  };
+  const p = CLASSICAL_DEFAULTS;
+
+  it("accepts a well-formed quad", () => {
+    expect(firstHardReject(passing, p)).toBeNull();
+  });
+
+  it("rejects a quad that is too small, and too large", () => {
+    expect(firstHardReject({ ...passing, areaFraction: 0.05 }, p)).toBe("rejected-area");
+    expect(firstHardReject({ ...passing, areaFraction: 0.99 }, p)).toBe("rejected-area");
+  });
+
+  it("rejects a quad longer than maxAspect", () => {
+    expect(firstHardReject({ ...passing, aspect: 20 }, p)).toBe("rejected-aspect");
+  });
+
+  // The reason minAspect is NOT dead code. computeMetrics falls back to
+  // `aspect = 0` when either mean side length is zero, and 0 < minAspect (0.4)
+  // fires. A 2026-09-05 review called this bound unreachable and was wrong;
+  // this test is what stops the next reader deleting it.
+  it("rejects a DEGENERATE quad, whose aspect is 0 rather than >= 1", () => {
+    expect(firstHardReject({ ...passing, aspect: 0 }, p)).toBe("rejected-aspect");
+  });
+
+  it("rejects corners outside the angle band, at both ends", () => {
+    expect(firstHardReject({ ...passing, minAngle: 30 }, p)).toBe("rejected-angle");
+    expect(firstHardReject({ ...passing, maxAngle: 150 }, p)).toBe("rejected-angle");
+  });
+
+  it("rejects a non-convex quad — the curled-receipt shape", () => {
+    expect(firstHardReject({ ...passing, convexity: 0.5 }, p)).toBe("rejected-convexity");
+  });
+
+  it("reports the FIRST failure, not all of them", () => {
+    const doomed = { ...passing, areaFraction: 0.01, aspect: 99, convexity: 0 };
+    expect(firstHardReject(doomed, p)).toBe("rejected-area");
+  });
+
+  it("treats each bound as inclusive at the threshold itself", () => {
+    expect(firstHardReject({ ...passing, areaFraction: p.minAreaFraction }, p)).toBeNull();
+    expect(firstHardReject({ ...passing, aspect: p.maxAspect }, p)).toBeNull();
+    expect(firstHardReject({ ...passing, minAngle: p.minAngleDeg }, p)).toBeNull();
+    expect(firstHardReject({ ...passing, maxAngle: p.maxAngleDeg }, p)).toBeNull();
   });
 });

--- a/frontend/src/lib/scanner/classical-detector.test.ts
+++ b/frontend/src/lib/scanner/classical-detector.test.ts
@@ -3,10 +3,12 @@ import {
   CLASSICAL_DEFAULTS,
   classifyScanResult,
   firstHardReject,
+  outcomeForNoQuad,
   scanThrowMessage,
   toQuad,
   type Metrics,
 } from "./classical-detector";
+import { REJECT_OUTCOMES, isRejectOutcome } from "./detector";
 
 /**
  * The silent-failure suite.
@@ -182,8 +184,101 @@ describe("firstHardReject — which gate threw the quad away", () => {
 
   it("treats each bound as inclusive at the threshold itself", () => {
     expect(firstHardReject({ ...passing, areaFraction: p.minAreaFraction }, p)).toBeNull();
+    expect(firstHardReject({ ...passing, areaFraction: p.maxAreaFraction }, p)).toBeNull();
+    expect(firstHardReject({ ...passing, aspect: p.minAspect }, p)).toBeNull();
     expect(firstHardReject({ ...passing, aspect: p.maxAspect }, p)).toBeNull();
     expect(firstHardReject({ ...passing, minAngle: p.minAngleDeg }, p)).toBeNull();
     expect(firstHardReject({ ...passing, maxAngle: p.maxAngleDeg }, p)).toBeNull();
+  });
+
+  /**
+   * The convexity floor is still a bare constant inside the module (promoting it
+   * to a param is T10). Nothing else pins its value, so this test is what stops
+   * that promotion silently moving the floor.
+   */
+  it("pins the convexity floor at 0.85, inclusive", () => {
+    expect(firstHardReject({ ...passing, convexity: 0.85 }, p)).toBeNull();
+    expect(firstHardReject({ ...passing, convexity: 0.8499 }, p)).toBe("rejected-convexity");
+  });
+
+  /**
+   * The hazard `toQuad` documents, arriving through a different door. Every gate
+   * is `x < t` / `x > t` and all NaN comparisons are false, so without an
+   * explicit finite check a NaN metric passes all four and reports as accepted —
+   * the viewfinder then draws nothing while the badge says a document was found.
+   */
+  it("REJECTS a non-finite metric rather than letting it pass every gate", () => {
+    expect(firstHardReject({ ...passing, areaFraction: NaN }, p)).toBe("rejected-area");
+    expect(firstHardReject({ ...passing, aspect: NaN }, p)).toBe("rejected-aspect");
+    expect(firstHardReject({ ...passing, minAngle: NaN }, p)).toBe("rejected-angle");
+    expect(firstHardReject({ ...passing, maxAngle: NaN }, p)).toBe("rejected-angle");
+    expect(firstHardReject({ ...passing, convexity: NaN }, p)).toBe("rejected-convexity");
+    expect(firstHardReject({ ...passing, areaFraction: Infinity }, p)).toBe("rejected-area");
+  });
+
+  it("reports every reject through the shared REJECT_OUTCOMES contract", () => {
+    // A reject the Lab cannot recognise is filed as "the scanner saw nothing",
+    // which is the conflation the outcome channel exists to remove.
+    const spoiled: Metrics[] = [
+      { ...passing, areaFraction: 0.01 },
+      { ...passing, aspect: 99 },
+      { ...passing, minAngle: 10 },
+      { ...passing, convexity: 0.1 },
+    ];
+    for (const m of spoiled) {
+      const r = firstHardReject(m, p);
+      expect(r).not.toBeNull();
+      expect(isRejectOutcome(r!)).toBe(true);
+    }
+  });
+});
+
+describe("outcomeForNoQuad — why did nothing come back", () => {
+  it("reports a detector failure as error", () => {
+    expect(outcomeForNoQuad({ rawCorners: null, error: "Scanner error: boom" })).toBe("error");
+    // Error wins even when corners are present: the detector broke.
+    expect(outcomeForNoQuad({ rawCorners: {}, error: "Scanner: bad" })).toBe("error");
+  });
+
+  it("reports corners that failed toQuad as malformed", () => {
+    expect(outcomeForNoQuad({ rawCorners: { topLeft: { x: NaN, y: 0 } } })).toBe("malformed-corners");
+  });
+
+  /**
+   * The load-bearing case. `classifyScanResult` stays deliberately silent on
+   * scanic's default empty-frame message, so a bare table arrives here with no
+   * error and no corners. Calling that an error would pin the viewfinder's
+   * badge on permanently.
+   */
+  it("reports an honest empty frame as no-contour", () => {
+    expect(outcomeForNoQuad({ rawCorners: null })).toBe("no-contour");
+    expect(outcomeForNoQuad(classifyScanResult({ success: false, message: "No document detected" })))
+      .toBe("no-contour");
+  });
+
+  it("never reports a no-quad state as a reject", () => {
+    const states = [
+      { rawCorners: null },
+      { rawCorners: {} },
+      { rawCorners: null, error: "x" },
+    ];
+    for (const s of states) expect(isRejectOutcome(outcomeForNoQuad(s))).toBe(false);
+  });
+});
+
+describe("REJECT_OUTCOMES", () => {
+  it("lists exactly the rejects, and every member carries the prefix", () => {
+    expect([...REJECT_OUTCOMES].sort()).toEqual(
+      ["rejected-angle", "rejected-area", "rejected-aspect", "rejected-convexity", "rejected-score"],
+    );
+    for (const o of REJECT_OUTCOMES) expect(o.startsWith("rejected-")).toBe(true);
+  });
+
+  it("recognises rejects and refuses everything else", () => {
+    expect(isRejectOutcome("rejected-area")).toBe(true);
+    expect(isRejectOutcome("no-contour")).toBe(false);
+    expect(isRejectOutcome("accepted")).toBe(false);
+    expect(isRejectOutcome("error")).toBe(false);
+    expect(isRejectOutcome(undefined)).toBe(false);
   });
 });

--- a/frontend/src/lib/scanner/classical-detector.ts
+++ b/frontend/src/lib/scanner/classical-detector.ts
@@ -1,13 +1,15 @@
 import { getScanner, initScanner } from "@/lib/opencv-loader";
 import { imageDataToCanvas } from "./canvas-utils";
 import { convexHullArea, dist, interiorAngles, lerp, polygonArea } from "./geometry";
-import type { Detector, DetectionOutcome, DetectionResult, Quad } from "./detector";
+import type { Detector, DetectionOutcome, DetectionResult, Quad, RejectOutcome } from "./detector";
 
-/** The subset of DetectionOutcome that `firstHardReject` can return. */
-export type HardReject = Extract<
-  DetectionOutcome,
-  "rejected-area" | "rejected-aspect" | "rejected-angle" | "rejected-convexity"
->;
+/**
+ * What `firstHardReject` can return: every reject except `rejected-score`,
+ * which only the ML detector's score threshold produces. Derived from
+ * `RejectOutcome` rather than re-listing the members, so a new reject added to
+ * the union lands here automatically.
+ */
+export type HardReject = Exclude<RejectOutcome, "rejected-score">;
 
 export interface ClassicalParams {
   shadowNorm: boolean;
@@ -73,11 +75,12 @@ export class ClassicalDetector implements Detector {
         score: 0,
         candidates: [],
         timingMs: performance.now() - start,
-        // Corners present but malformed is a failure too; a plain miss above
-        // has already set `error`, and a genuine "nothing found" cannot reach
-        // here without one.
+        // Corners present but malformed is a failure too. A genuine "nothing
+        // found" DOES reach here without an error — `classifyScanResult` stays
+        // deliberately silent on scanic's default empty-frame message — and
+        // that is exactly the `no-contour` outcome below.
         error: error ?? (rawCorners ? "Scanner returned malformed corners" : undefined),
-        outcome: error ? "error" : rawCorners ? "malformed-corners" : "no-contour",
+        outcome: outcomeForNoQuad(classified),
       };
     }
 
@@ -229,6 +232,36 @@ export function classifyScanResult(r: {
   return { rawCorners: null, error: "Scanner returned no corners" };
 }
 
+/** The outcomes reachable when no usable quad came back. */
+export type NoQuadOutcome = Extract<
+  DetectionOutcome,
+  "error" | "malformed-corners" | "no-contour"
+>;
+
+/**
+ * Why did this scan produce no usable quad?
+ *
+ * Three different states that the viewfinder renders identically, so the only
+ * way to tell them apart downstream is to name them here:
+ *
+ *   error             the detector broke -- it never looked at this frame
+ *   malformed-corners it returned corners, but they were unusable (NaN, missing)
+ *   no-contour        it looked and honestly found nothing. A bare table.
+ *
+ * Extracted from `detect()` for the same reason `classifyScanResult` and
+ * `toQuad` were: `detect()` needs a canvas, this decision does not, so keeping
+ * it here makes it reachable from the node-env test suite.
+ *
+ * Note `malformed-corners` also carries an `error` string on the result, since
+ * malformed output IS a detector failure from the caller's point of view. The
+ * distinction is kept because "returned garbage" and "could not run" point at
+ * different bugs.
+ */
+export function outcomeForNoQuad(c: ScanClassification): NoQuadOutcome {
+  if (c.error) return "error";
+  return c.rawCorners ? "malformed-corners" : "no-contour";
+}
+
 /** Message for a scan() that threw rather than resolved. Always a failure. */
 export function scanThrowMessage(e: unknown): string {
   return `Scanner error: ${e instanceof Error ? e.message : String(e)}`;
@@ -332,6 +365,16 @@ const MIN_CONVEXITY = 0.85;
  * redundancy is cheap and it stops the guard order becoming load-bearing.)
  */
 export function firstHardReject(m: Metrics, p: ClassicalParams): HardReject | null {
+  // NaN first, for the reason `toQuad` spells out: every check below is `x < t`
+  // or `x > t`, and ALL NaN comparisons are false, so a NaN metric would sail
+  // through all four and be reported as accepted. `toQuad` blocks NaN corner
+  // coordinates, but `areaFraction = area / max(imageArea, 1)` is NaN for a
+  // NaN-dimensioned ImageData, which is a different way in.
+  if (!Number.isFinite(m.areaFraction)) return "rejected-area";
+  if (!Number.isFinite(m.aspect)) return "rejected-aspect";
+  if (!Number.isFinite(m.minAngle) || !Number.isFinite(m.maxAngle)) return "rejected-angle";
+  if (!Number.isFinite(m.convexity)) return "rejected-convexity";
+
   if (m.areaFraction < p.minAreaFraction || m.areaFraction > p.maxAreaFraction) return "rejected-area";
   if (m.aspect < p.minAspect || m.aspect > p.maxAspect) return "rejected-aspect";
   if (m.minAngle < p.minAngleDeg || m.maxAngle > p.maxAngleDeg) return "rejected-angle";

--- a/frontend/src/lib/scanner/classical-detector.ts
+++ b/frontend/src/lib/scanner/classical-detector.ts
@@ -1,7 +1,13 @@
 import { getScanner, initScanner } from "@/lib/opencv-loader";
 import { imageDataToCanvas } from "./canvas-utils";
 import { convexHullArea, dist, interiorAngles, lerp, polygonArea } from "./geometry";
-import type { Detector, DetectionResult, Quad } from "./detector";
+import type { Detector, DetectionOutcome, DetectionResult, Quad } from "./detector";
+
+/** The subset of DetectionOutcome that `firstHardReject` can return. */
+export type HardReject = Extract<
+  DetectionOutcome,
+  "rejected-area" | "rejected-aspect" | "rejected-angle" | "rejected-convexity"
+>;
 
 export interface ClassicalParams {
   shadowNorm: boolean;
@@ -71,25 +77,22 @@ export class ClassicalDetector implements Detector {
         // has already set `error`, and a genuine "nothing found" cannot reach
         // here without one.
         error: error ?? (rawCorners ? "Scanner returned malformed corners" : undefined),
+        outcome: error ? "error" : rawCorners ? "malformed-corners" : "no-contour",
       };
     }
 
     const metrics = computeMetrics(quad, image);
-    if (!passesHardRejects(metrics, p)) {
-      return {
-        corners: null,
-        score: metrics.score(p),
-        candidates: [{ quad, score: metrics.score(p) }],
-        timingMs: performance.now() - start,
-      };
-    }
-
     const score = metrics.score(p);
+    const reject = firstHardReject(metrics, p);
+    // A rejected quad still travels in `candidates`. It is the only evidence
+    // that scanic DID find something here, and the Lab needs it to tell a
+    // too-tight threshold apart from a scene the scanner is blind on.
     return {
-      corners: quad,
+      corners: reject ? null : quad,
       score,
       candidates: [{ quad, score }],
       timingMs: performance.now() - start,
+      outcome: reject ?? "accepted",
     };
   }
 }
@@ -248,7 +251,8 @@ export function toQuad(raw: any): Quad | null {
   return { topLeft: tl, topRight: tr, bottomRight: br, bottomLeft: bl };
 }
 
-interface Metrics {
+/** Exported so `firstHardReject` can be unit-tested against synthetic metrics. */
+export interface Metrics {
   area: number;
   areaFraction: number;
   convexity: number;
@@ -305,12 +309,34 @@ function computeMetrics(quad: Quad, image: ImageData): Metrics {
   };
 }
 
-function passesHardRejects(m: Metrics, p: ClassicalParams): boolean {
-  if (m.areaFraction < p.minAreaFraction || m.areaFraction > p.maxAreaFraction) return false;
-  if (m.aspect < p.minAspect || m.aspect > p.maxAspect) return false;
-  if (m.minAngle < p.minAngleDeg || m.maxAngle > p.maxAngleDeg) return false;
-  if (m.convexity < 0.85) return false;
-  return true;
+/** Convexity floor. Still hardcoded; promoting it to a param is T10. */
+const MIN_CONVEXITY = 0.85;
+
+/**
+ * The first hard reject a quad trips, or null if it survives all of them.
+ *
+ * Returns WHICH gate fired rather than a bare boolean, because "we found a quad
+ * and threw it away" and "we found nothing" are the two hypotheses the Lab has
+ * to tell apart, and a boolean collapses them into the same `corners: null`.
+ * Order is deliberate and load-bearing for the degenerate case below: it reports
+ * the first failure, not all of them.
+ *
+ * Exported for tests. It is pure — it takes `Metrics`, not `ImageData` — so it
+ * runs in the node-env vitest suite with no DOM.
+ *
+ * ON `minAspect`: this reads like dead code and is not. `computeMetrics` sets
+ * `aspect = max/min`, which is >= 1 for any real quad, so a 0.4 floor looks
+ * unreachable. But the ternary at its definition falls back to `0` when either
+ * mean side length is zero, so a DEGENERATE quad scores 0 and this bound is what
+ * catches it. (`minAreaFraction` would catch it too, one line earlier — the
+ * redundancy is cheap and it stops the guard order becoming load-bearing.)
+ */
+export function firstHardReject(m: Metrics, p: ClassicalParams): HardReject | null {
+  if (m.areaFraction < p.minAreaFraction || m.areaFraction > p.maxAreaFraction) return "rejected-area";
+  if (m.aspect < p.minAspect || m.aspect > p.maxAspect) return "rejected-aspect";
+  if (m.minAngle < p.minAngleDeg || m.maxAngle > p.maxAngleDeg) return "rejected-angle";
+  if (m.convexity < MIN_CONVEXITY) return "rejected-convexity";
+  return null;
 }
 
 function sampleInterior(quad: Quad, image: ImageData): { uniformity: number; textDensity: number } {

--- a/frontend/src/lib/scanner/coords.test.ts
+++ b/frontend/src/lib/scanner/coords.test.ts
@@ -40,7 +40,11 @@ function expectQuadClose(a: Quad, b: Quad, digits = 9) {
 describe("detection <-> video round trip", () => {
   // The live loop detects on a downscale of the video frame and reports the
   // ratio it actually used. ScannerPage converts with 1 / detectionScale.
-  const DETECTION_SCALE = 0.4;           // 1080x1920 video -> 432x768 detection
+  // An arbitrary ratio fixture, NOT the production value — the live loop now
+  // derives its ratio from detectionSizeFor(video, DETECTION_MAX_EDGE), which
+  // varies with what the camera ladder negotiated. What is under test here is
+  // that scaleQuad round-trips through ANY ratio, so a fixed one is the point.
+  const DETECTION_SCALE = 0.4;
   const inDetectionSpace = quad([50, 80], [380, 70], [390, 700], [40, 690]);
 
   it("is an identity round trip", () => {

--- a/frontend/src/lib/scanner/detection-size.test.ts
+++ b/frontend/src/lib/scanner/detection-size.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from "vitest";
+import { DETECTION_MAX_EDGE, detectionSizeFor } from "./detection-size";
+
+/**
+ * The no-upscale clamp is the reason this function exists rather than an inline
+ * `Math.round(videoWidth * k)`.
+ *
+ * Until 2026-09-05 the live loop sized detection as a FRACTION of the video
+ * (`videoWidth * 0.4`), which is monotonically a downscale and therefore safe by
+ * construction. A fixed 800px target is not: on a small source it would happily
+ * invent pixels. These tests are what keep the replacement honest.
+ */
+describe("detectionSizeFor", () => {
+  it("caps a 4K landscape frame at the target edge", () => {
+    const s = detectionSizeFor(3840, 2160, 800);
+    expect(s.w).toBe(800);
+    expect(s.h).toBe(450);
+    expect(s.scale).toBeCloseTo(800 / 3840, 10);
+  });
+
+  // Android routinely hands back a portrait-oriented track. The LONGEST edge is
+  // capped either way; which axis that is must not matter.
+  it("caps a 4K portrait frame on its longest edge, not its width", () => {
+    const s = detectionSizeFor(2160, 3840, 800);
+    expect(s.h).toBe(800);
+    expect(s.w).toBe(450);
+    expect(s.scale).toBeCloseTo(800 / 3840, 10);
+  });
+
+  it("handles a square frame", () => {
+    const s = detectionSizeFor(1000, 1000, 800);
+    expect(s).toEqual({ w: 800, h: 800, scale: 0.8 });
+  });
+
+  it("preserves aspect ratio", () => {
+    const s = detectionSizeFor(3840, 2160, 800);
+    expect(s.w / s.h).toBeCloseTo(3840 / 2160, 2);
+  });
+
+  // THE regression this file exists for.
+  it("NEVER upscales a source already within the target", () => {
+    const small = detectionSizeFor(640, 480, 800);
+    expect(small).toEqual({ w: 640, h: 480, scale: 1 });
+
+    const tiny = detectionSizeFor(100, 50, 800);
+    expect(tiny).toEqual({ w: 100, h: 50, scale: 1 });
+  });
+
+  it("leaves a frame exactly at the target untouched, scale exactly 1", () => {
+    const s = detectionSizeFor(800, 600, 800);
+    expect(s).toEqual({ w: 800, h: 600, scale: 1 });
+    // Exactly 1, not 0.9999...: callers branch on `scale === 1` to skip a copy.
+    expect(s.scale).toBe(1);
+  });
+
+  it("returns scale 1 for a zero-size source rather than a fabricated size", () => {
+    // videoWidth is 0 between camera-ready and the first decoded frame.
+    expect(detectionSizeFor(0, 0, 800)).toEqual({ w: 0, h: 0, scale: 1 });
+    expect(detectionSizeFor(1920, 0, 800).scale).not.toBeNaN();
+  });
+
+  it("returns scale 1 for a non-positive or non-finite maxEdge", () => {
+    expect(detectionSizeFor(3840, 2160, 0)).toEqual({ w: 3840, h: 2160, scale: 1 });
+    expect(detectionSizeFor(3840, 2160, -100)).toEqual({ w: 3840, h: 2160, scale: 1 });
+    expect(detectionSizeFor(3840, 2160, NaN)).toEqual({ w: 3840, h: 2160, scale: 1 });
+  });
+
+  it("never returns a zero dimension for an extreme aspect ratio", () => {
+    // A 1:40 sliver would round its short edge to 0 without the max(1, ...).
+    const s = detectionSizeFor(4000, 100, 800);
+    expect(s.w).toBe(800);
+    expect(s.h).toBeGreaterThanOrEqual(1);
+  });
+
+  it("defaults to DETECTION_MAX_EDGE", () => {
+    expect(detectionSizeFor(3840, 2160)).toEqual(detectionSizeFor(3840, 2160, DETECTION_MAX_EDGE));
+  });
+
+  /**
+   * The mapping the viewfinder actually performs: corners detected in the
+   * downscaled frame are multiplied by `1 / scale` to land in video space.
+   */
+  it("round-trips a coordinate back to video space through `scale`", () => {
+    const s = detectionSizeFor(3840, 2160, 800);
+    const xInDetection = s.w; // the far edge
+    expect(xInDetection / s.scale).toBeCloseTo(3840, 6);
+  });
+});

--- a/frontend/src/lib/scanner/detection-size.test.ts
+++ b/frontend/src/lib/scanner/detection-size.test.ts
@@ -56,7 +56,45 @@ describe("detectionSizeFor", () => {
   it("returns scale 1 for a zero-size source rather than a fabricated size", () => {
     // videoWidth is 0 between camera-ready and the first decoded frame.
     expect(detectionSizeFor(0, 0, 800)).toEqual({ w: 0, h: 0, scale: 1 });
-    expect(detectionSizeFor(1920, 0, 800).scale).not.toBeNaN();
+  });
+
+  /**
+   * A PARTIALLY-zero source is the one that actually bit. Guarding the longest
+   * edge lets (1920, 0) through: it scales to w=800, and `Math.max(1, ...)`
+   * turns the zero height into 1, yielding an 800x1 sliver. The detect loop
+   * guards `video.videoWidth > 0` and NOT videoHeight, so this was reachable.
+   *
+   * The original test here asserted only `.scale` was `not.toBeNaN()`, which is
+   * true of the fabricated 0.4166..., so it passed while the bug was live.
+   * Assert the whole object.
+   */
+  it("returns the source unchanged when EITHER axis is zero", () => {
+    expect(detectionSizeFor(1920, 0, 800)).toEqual({ w: 1920, h: 0, scale: 1 });
+    expect(detectionSizeFor(0, 1080, 800)).toEqual({ w: 0, h: 1080, scale: 1 });
+  });
+
+  it("returns the source unchanged when either axis is non-finite", () => {
+    // A NaN canvas dimension propagates into areaFraction and defeats every
+    // hard reject downstream, since all NaN comparisons are false.
+    expect(detectionSizeFor(NaN, 1000, 800)).toEqual({ w: NaN, h: 1000, scale: 1 });
+    expect(detectionSizeFor(1920, NaN, 800)).toEqual({ w: 1920, h: NaN, scale: 1 });
+    // Infinity is the sneaky one: it survives a shortest-edge check when the
+    // other axis is normal, then scale computes to 0 and every downstream
+    // `1 / scale` becomes Infinity.
+    expect(detectionSizeFor(Infinity, 1080, 800)).toEqual({ w: Infinity, h: 1080, scale: 1 });
+    expect(detectionSizeFor(1920, Infinity, 800).scale).toBe(1);
+  });
+
+  it("never returns a scale of 0, whatever it is handed", () => {
+    const inputs: [number, number][] = [
+      [0, 0], [1920, 0], [0, 1080], [NaN, NaN], [NaN, 1080], [1920, NaN],
+      [Infinity, 1080], [1920, Infinity], [-100, 200], [3840, 2160], [640, 480],
+    ];
+    for (const [w, h] of inputs) {
+      const s = detectionSizeFor(w, h, 800);
+      expect(s.scale).toBeGreaterThan(0);
+      expect(Number.isFinite(s.scale)).toBe(true);
+    }
   });
 
   it("returns scale 1 for a non-positive or non-finite maxEdge", () => {

--- a/frontend/src/lib/scanner/detection-size.ts
+++ b/frontend/src/lib/scanner/detection-size.ts
@@ -1,0 +1,72 @@
+/**
+ * The one resolution the classical detector is tuned for.
+ *
+ * `detector.ts` documents DETECTION SPACE as "~800px longest edge", and every
+ * `ClassicalParams` default was tuned there. Three places have to agree on it:
+ *
+ *   - the live viewfinder loop      (CameraViewfinder)
+ *   - the review-entry re-detect    (ScannerPage)
+ *   - the Lab's detect / eval       (ScannerLabPage)
+ *
+ * Scanic's own `maxProcessingDimension` (opencv-loader.ts) is kept EQUAL to this
+ * number but is deliberately NOT derived from it: that bound belongs to scanic,
+ * and a scanic upgrade that changes its default should not be silently
+ * overridden by ours.
+ *
+ * Why 800 specifically, and why a fixed edge rather than a fraction of the
+ * video: scanic downsamples anything larger to 800 before it looks for a
+ * contour (`prepareScaleAndGrayscale`, scanic.js:961), so pixels above this are
+ * discarded — but only AFTER `classical-detector.preprocess()` has paid five
+ * per-pixel JS passes and two canvas round-trips on them. A fraction of the
+ * video silently rescales that cost with whatever the camera ladder negotiated;
+ * a fixed edge does not.
+ */
+export const DETECTION_MAX_EDGE = 800;
+
+export interface DetectionSize {
+  w: number;
+  h: number;
+  /**
+   * newSize / originalSize — ONE uniform ratio for both axes, exactly 1 when
+   * the source was left alone. Callers map coordinates back with this and must
+   * not recompute it from `w / srcW`: the two differ by up to half a pixel of
+   * rounding, and deriving the same ratio twice is how coordinate-space bugs
+   * are born (see `detector.ts`'s COORDINATE SPACES header).
+   */
+  scale: number;
+}
+
+/**
+ * Size a detection frame from a source frame, capped at `maxEdge`.
+ *
+ * NEVER UPSCALES. This is the property that makes a fixed edge safe where the
+ * old `videoWidth * 0.4` was safe for free: a fraction below 1 is monotonically
+ * a downscale, but a fixed 800px target is not. A 640x480 webcam, or the bottom
+ * rung of the camera ladder, would otherwise be blown up to 800px — more pixels
+ * than the source, every one of them invented by `drawImage`, at strictly more
+ * cost than doing nothing. `scale` stays exactly 1 there so callers can skip the
+ * copy entirely.
+ *
+ * Non-positive or non-finite inputs fall through the same guard and are returned
+ * unchanged with `scale: 1`, rather than being turned into a plausible-looking
+ * size. `video.videoWidth` is 0 between camera-ready and the first decoded
+ * frame, and callers already guard it; this only ensures nothing downstream
+ * receives a fabricated dimension.
+ */
+export function detectionSizeFor(
+  srcW: number,
+  srcH: number,
+  maxEdge: number = DETECTION_MAX_EDGE,
+): DetectionSize {
+  const longest = Math.max(srcW, srcH);
+  // `NaN > 0` is false, so this one guard covers zero, negative and NaN.
+  if (!(maxEdge > 0) || !(longest > 0) || longest <= maxEdge) {
+    return { w: srcW, h: srcH, scale: 1 };
+  }
+  const scale = maxEdge / longest;
+  return {
+    w: Math.max(1, Math.round(srcW * scale)),
+    h: Math.max(1, Math.round(srcH * scale)),
+    scale,
+  };
+}

--- a/frontend/src/lib/scanner/detection-size.ts
+++ b/frontend/src/lib/scanner/detection-size.ts
@@ -59,8 +59,19 @@ export function detectionSizeFor(
   maxEdge: number = DETECTION_MAX_EDGE,
 ): DetectionSize {
   const longest = Math.max(srcW, srcH);
-  // `NaN > 0` is false, so this one guard covers zero, negative and NaN.
-  if (!(maxEdge > 0) || !(longest > 0) || longest <= maxEdge) {
+  // Two guards, because one axis being bad is enough and they fail differently.
+  //
+  // SHORTEST > 0 — guarding the longest edge alone lets a partially-zero source
+  // through: (1920, 0) has a longest edge of 1920, reaches the scaling below,
+  // and `Math.max(1, Math.round(0 * scale))` invents a height of 1, an 800x1
+  // sliver. `Math.min(NaN, x)` is NaN and `NaN > 0` is false, so this also
+  // covers NaN on either axis.
+  //
+  // LONGEST finite — Infinity survives the check above whenever the other axis
+  // is a normal number: (Infinity, 1080) has a shortest edge of 1080, then
+  // `scale = 800 / Infinity` is 0, `w` comes out NaN, and `scale: 0` becomes
+  // Infinity at every `1 / scale` call site downstream.
+  if (!(maxEdge > 0) || !(Math.min(srcW, srcH) > 0) || !Number.isFinite(longest) || longest <= maxEdge) {
     return { w: srcW, h: srcH, scale: 1 };
   }
   const scale = maxEdge / longest;

--- a/frontend/src/lib/scanner/detector.ts
+++ b/frontend/src/lib/scanner/detector.ts
@@ -66,14 +66,33 @@ export type DetectionOutcome =
   /** The detector failed. Always paired with `error`. */
   | "error";
 
-/** The hard-reject outcomes, i.e. "found something, then threw it away". */
-export const REJECT_OUTCOMES: readonly DetectionOutcome[] = [
-  "rejected-area",
-  "rejected-aspect",
-  "rejected-angle",
-  "rejected-convexity",
-  "rejected-score",
-];
+/** The outcomes meaning "found something, then threw it away". */
+export type RejectOutcome = Extract<DetectionOutcome, `rejected-${string}`>;
+
+/**
+ * Exhaustiveness is enforced by the compiler, not by memory.
+ *
+ * `Record<RejectOutcome, true>` fails to typecheck the moment a new
+ * `rejected-*` member joins the union and is not listed here. The obvious
+ * spelling — `const REJECT_OUTCOMES: readonly DetectionOutcome[] = [...]` — is
+ * the trap: it accepts any subset, so a new reject silently misses the list and
+ * the Lab files it under "the scanner saw nothing", which is the exact
+ * conflation this outcome channel exists to remove.
+ */
+const REJECT_OUTCOME_SET: Record<RejectOutcome, true> = {
+  "rejected-area": true,
+  "rejected-aspect": true,
+  "rejected-angle": true,
+  "rejected-convexity": true,
+  "rejected-score": true,
+};
+
+export const REJECT_OUTCOMES = Object.keys(REJECT_OUTCOME_SET) as RejectOutcome[];
+
+/** Did this result find a quad and then discard it? */
+export function isRejectOutcome(o: DetectionOutcome | undefined): o is RejectOutcome {
+  return o !== undefined && o in REJECT_OUTCOME_SET;
+}
 
 export interface DetectionResult {
   /** Detected quad in the same space as the ImageData passed to detect(), or null. */

--- a/frontend/src/lib/scanner/detector.ts
+++ b/frontend/src/lib/scanner/detector.ts
@@ -5,14 +5,16 @@
  * this module's documentation exists to prevent. Mirrors the "Coordinate
  * spaces" section of docs/designs/mobile-scanner-detection-and-capture.md.
  *
- *   DETECTION SPACE                    ~800px longest edge (was 432x768)
+ *   DETECTION SPACE                    800px longest edge, DETECTION_MAX_EDGE
  *     Detector.detect() operates here
  *     ClassicalParams are tuned here
  *     blur radius = width * 0.125, so cost scales with this
+ *     A FIXED edge, never a fraction of the video: a fraction silently
+ *     quadrupled this when the camera ladder was raised to 4K.
  *         |
- *         |  x (videoW / detW)          <- converted at the detector boundary
+ *         |  / detectionSizeFor().scale   <- converted at the detector boundary
  *         v
- *   VIDEO SPACE                        1080x1920 (or 1920x1080)
+ *   VIDEO SPACE                        up to 3840x2160 (either orientation)
  *     onCapture(imageData, corners)    <- corners cross HERE, in video pixels
  *     scanic.extract() consumes this
  *     CaptureReview { raw, corners }
@@ -34,12 +36,57 @@
 export type Pt = { x: number; y: number };
 export type Quad = { topLeft: Pt; topRight: Pt; bottomRight: Pt; bottomLeft: Pt };
 
+/**
+ * WHY this exists: `corners: null` has more than one cause, and they call for
+ * opposite fixes.
+ *
+ * The viewfinder renders every null the same way ("Position document in
+ * frame"), so a document the underlying scanner never found is indistinguishable
+ * from one it found and our own geometry gates then threw away. Those are
+ * different bugs: the first says the scanner is blind on this scene, the second
+ * says a threshold is too tight. Tuning the thresholds cannot fix the first, and
+ * making detection faster or sharper cannot fix the second.
+ *
+ * `error` already separates "the detector broke" from "the detector ran". This
+ * splits the second half of that: WHY did a run that worked produce nothing.
+ */
+export type DetectionOutcome =
+  /** A quad was produced and survived every gate. */
+  | "accepted"
+  /** The underlying scanner ran and found no document. An honest empty frame. */
+  | "no-contour"
+  /** Corners came back but were unusable (missing, NaN, Infinity). */
+  | "malformed-corners"
+  | "rejected-area"
+  | "rejected-aspect"
+  | "rejected-angle"
+  | "rejected-convexity"
+  /** ML only: below `scoreThreshold`. */
+  | "rejected-score"
+  /** The detector failed. Always paired with `error`. */
+  | "error";
+
+/** The hard-reject outcomes, i.e. "found something, then threw it away". */
+export const REJECT_OUTCOMES: readonly DetectionOutcome[] = [
+  "rejected-area",
+  "rejected-aspect",
+  "rejected-angle",
+  "rejected-convexity",
+  "rejected-score",
+];
+
 export interface DetectionResult {
   /** Detected quad in the same space as the ImageData passed to detect(), or null. */
   corners: Quad | null;
   score: number;
   candidates?: { quad: Quad; score: number }[];
   timingMs: number;
+  /**
+   * Why this result looks the way it does. Optional so a third-party Detector
+   * need not implement it; consumers must tolerate `undefined` rather than
+   * treating a missing outcome as an error.
+   */
+  outcome?: DetectionOutcome;
   /**
    * Set when the detector FAILED: it could not init, could not load, threw, or
    * reported that it could not run to a conclusion.

--- a/frontend/src/lib/scanner/geometry.test.ts
+++ b/frontend/src/lib/scanner/geometry.test.ts
@@ -8,8 +8,10 @@ import {
   orderQuadByAngle,
   quadAreaFraction,
   clampPtToFrame,
+  quadsEqual,
+  scaleDetectionResult,
 } from "./geometry";
-import type { Pt, Quad } from "./detector";
+import type { DetectionResult, Pt, Quad } from "./detector";
 
 const quadPts = (q: Quad): Pt[] => [q.topLeft, q.topRight, q.bottomRight, q.bottomLeft];
 
@@ -214,5 +216,116 @@ describe("clampPtToFrame", () => {
 
   it("keeps points exactly on the boundary", () => {
     expect(clampPtToFrame({ x: 0, y: 200 }, 100, 200)).toEqual({ x: 0, y: 200 });
+  });
+});
+
+const mkQuad = (x = 0, y = 0): Quad => ({
+  topLeft: { x, y },
+  topRight: { x: x + 100, y },
+  bottomRight: { x: x + 100, y: y + 200 },
+  bottomLeft: { x, y: y + 200 },
+});
+
+describe("quadsEqual — the replacement for object identity", () => {
+  it("matches two structurally identical but distinct objects", () => {
+    const a = mkQuad();
+    const b = mkQuad();
+    expect(a).not.toBe(b); // distinct objects, the whole point
+    expect(quadsEqual(a, b)).toBe(true);
+  });
+
+  it("matches a quad against itself", () => {
+    const a = mkQuad();
+    expect(quadsEqual(a, a)).toBe(true);
+  });
+
+  it("rejects a quad with any single corner moved", () => {
+    const a = mkQuad();
+    for (const k of ["topLeft", "topRight", "bottomRight", "bottomLeft"] as const) {
+      const b = { ...mkQuad(), [k]: { x: 999, y: 999 } };
+      expect(quadsEqual(a, b)).toBe(false);
+    }
+  });
+
+  it("tolerates float drift from a scale-and-back round trip", () => {
+    const a = mkQuad();
+    const roundTripped = scaleQuadTwice(a, 1 / 3);
+    expect(quadsEqual(a, roundTripped)).toBe(true);
+  });
+
+  it("rejects a difference larger than epsilon", () => {
+    const a = mkQuad();
+    const b = { ...mkQuad(), topLeft: { x: 0.01, y: 0 } };
+    expect(quadsEqual(a, b)).toBe(false);
+    expect(quadsEqual(a, b, 0.1)).toBe(true);
+  });
+});
+
+/** Scale down then back up, so float error is real but tiny. */
+function scaleQuadTwice(q: Quad, k: number): Quad {
+  const down = {
+    topLeft: { x: q.topLeft.x * k, y: q.topLeft.y * k },
+    topRight: { x: q.topRight.x * k, y: q.topRight.y * k },
+    bottomRight: { x: q.bottomRight.x * k, y: q.bottomRight.y * k },
+    bottomLeft: { x: q.bottomLeft.x * k, y: q.bottomLeft.y * k },
+  };
+  return {
+    topLeft: { x: down.topLeft.x / k, y: down.topLeft.y / k },
+    topRight: { x: down.topRight.x / k, y: down.topRight.y / k },
+    bottomRight: { x: down.bottomRight.x / k, y: down.bottomRight.y / k },
+    bottomLeft: { x: down.bottomLeft.x / k, y: down.bottomLeft.y / k },
+  };
+}
+
+describe("scaleDetectionResult", () => {
+  const base = (over: Partial<DetectionResult> = {}): DetectionResult => ({
+    corners: mkQuad(),
+    score: 0.7,
+    candidates: [{ quad: mkQuad(), score: 0.7 }],
+    timingMs: 12,
+    outcome: "accepted",
+    ...over,
+  });
+
+  it("is a no-op at k === 1, returning the same object", () => {
+    const r = base();
+    expect(scaleDetectionResult(r, 1)).toBe(r);
+  });
+
+  it("scales corners and candidates by the same factor", () => {
+    const out = scaleDetectionResult(base(), 2);
+    expect(out.corners!.bottomRight).toEqual({ x: 200, y: 400 });
+    expect(out.candidates![0].quad.bottomRight).toEqual({ x: 200, y: 400 });
+  });
+
+  // A rejected result: corners null, but the candidate still carries the quad
+  // scanic found. Leaving it in detector space would misplace the near-miss
+  // outline the Lab draws from it.
+  it("scales the candidate of a REJECTED result, leaving corners null", () => {
+    const out = scaleDetectionResult(base({ corners: null, outcome: "rejected-convexity" }), 2);
+    expect(out.corners).toBeNull();
+    expect(out.candidates![0].quad.bottomRight).toEqual({ x: 200, y: 400 });
+    expect(out.outcome).toBe("rejected-convexity");
+  });
+
+  it("survives an absent candidates array", () => {
+    const out = scaleDetectionResult(base({ candidates: undefined }), 2);
+    expect(out.candidates).toBeUndefined();
+    expect(out.corners!.bottomRight).toEqual({ x: 200, y: 400 });
+  });
+
+  it("passes score, timingMs, outcome and error through untouched", () => {
+    const out = scaleDetectionResult(base({ error: "boom", outcome: "error" }), 2);
+    expect(out.score).toBe(0.7);
+    expect(out.timingMs).toBe(12);
+    expect(out.outcome).toBe("error");
+    expect(out.error).toBe("boom");
+  });
+
+  it("does not mutate its input", () => {
+    const r = base();
+    scaleDetectionResult(r, 2);
+    expect(r.corners!.bottomRight).toEqual({ x: 100, y: 200 });
+    expect(r.candidates![0].quad.bottomRight).toEqual({ x: 100, y: 200 });
   });
 });

--- a/frontend/src/lib/scanner/geometry.ts
+++ b/frontend/src/lib/scanner/geometry.ts
@@ -9,7 +9,7 @@
  * A quad written TL -> TR -> BR -> BL therefore winds clockwise on screen.
  */
 
-import type { Pt, Quad } from "./detector";
+import type { DetectionResult, Pt, Quad } from "./detector";
 
 /** Shoelace area of an arbitrary polygon (absolute value, so winding-agnostic). */
 export function polygonArea(pts: Pt[]): number {
@@ -176,6 +176,50 @@ export function scaleQuad(q: Quad, k: number): Quad {
     topRight: { x: q.topRight.x * k, y: q.topRight.y * k },
     bottomRight: { x: q.bottomRight.x * k, y: q.bottomRight.y * k },
     bottomLeft: { x: q.bottomLeft.x * k, y: q.bottomLeft.y * k },
+  };
+}
+
+/**
+ * Do two quads describe the same four corners?
+ *
+ * Exists so consumers can stop using object identity (`a === b`) to ask this.
+ * Identity is a tempting dedupe key when a detector returns the same object in
+ * both `corners` and `candidates[0].quad`, but it is a contract nothing in the
+ * type system enforces: the moment any transform maps over a result, the two
+ * become separate objects and the identity check silently stops matching. That
+ * happened here on 2026-09-05 — a downscale-and-rescale step split them, and the
+ * Lab overlay began drawing the accepted quad twice with no test able to catch
+ * it, because the symptom is purely visual.
+ *
+ * Epsilon rather than exact equality: the quads being compared have usually been
+ * through a float scale-and-back, so bitwise equality is not the question being
+ * asked. The default is far tighter than a pixel.
+ */
+export function quadsEqual(a: Quad, b: Quad, epsilon = 1e-6): boolean {
+  const keys = ["topLeft", "topRight", "bottomRight", "bottomLeft"] as const;
+  return keys.every(
+    (k) => Math.abs(a[k].x - b[k].x) <= epsilon && Math.abs(a[k].y - b[k].y) <= epsilon,
+  );
+}
+
+/**
+ * Scale every quad a detection result carries by `k`, leaving the rest intact.
+ *
+ * Pure: the caller does the canvas work, this does the arithmetic. Extracted so
+ * the coordinate mapping is reachable from the node-env test suite — the same
+ * reason `classifyScanResult` and `toQuad` were pulled out of `detect()`.
+ *
+ * `candidates` matters as much as `corners`: it carries the REJECTED quad, which
+ * is the whole point of the reject breakdown, and leaving it in the detector's
+ * space while `corners` moves to the caller's would put a landmine under the
+ * first consumer that draws it.
+ */
+export function scaleDetectionResult(result: DetectionResult, k: number): DetectionResult {
+  if (k === 1) return result;
+  return {
+    ...result,
+    corners: result.corners ? scaleQuad(result.corners, k) : null,
+    candidates: result.candidates?.map((c) => ({ ...c, quad: scaleQuad(c.quad, k) })),
   };
 }
 

--- a/frontend/src/lib/scanner/ml-detector.ts
+++ b/frontend/src/lib/scanner/ml-detector.ts
@@ -39,6 +39,7 @@ export class MLDetector implements Detector {
         corners: null,
         score: 0,
         candidates: [],
+        outcome: "error",
         timingMs: 0,
         error: "No ML model configured",
       };
@@ -54,6 +55,7 @@ export class MLDetector implements Detector {
         corners: null,
         score: 0,
         candidates: [],
+        outcome: "error",
         timingMs: performance.now() - start,
         error: `ML model load failed: ${message}`,
       };
@@ -66,6 +68,7 @@ export class MLDetector implements Detector {
         corners: null,
         score: 0,
         candidates: [],
+        outcome: "error",
         timingMs: performance.now() - start,
         error: "ML model load failed: session unavailable",
       };
@@ -85,6 +88,7 @@ export class MLDetector implements Detector {
         corners: null,
         score: 0,
         candidates: [],
+        outcome: "error",
         timingMs: performance.now() - start,
         error: `ML inference failed: ${message}`,
       };
@@ -102,6 +106,7 @@ export class MLDetector implements Detector {
         corners: null,
         score: 0,
         candidates: [],
+        outcome: "error",
         timingMs: performance.now() - start,
         error: "ML output did not match the expected tensor shape",
       };

--- a/frontend/src/lib/scanner/ml-detector.ts
+++ b/frontend/src/lib/scanner/ml-detector.ts
@@ -115,6 +115,10 @@ export class MLDetector implements Detector {
       score,
       candidates: [{ quad: corners, score }],
       timingMs: performance.now() - start,
+      // A below-threshold score is this detector's only "found something, threw
+      // it away" path — the ML analogue of a classical hard reject, and the
+      // reason the Lab's breakdown can compare the two detectors at all.
+      outcome: accepted ? "accepted" : "rejected-score",
     };
   }
 

--- a/frontend/src/lib/scanner/smoother.ts
+++ b/frontend/src/lib/scanner/smoother.ts
@@ -41,7 +41,26 @@ export interface SmootherOptions {
   warmupFrames?: number;
   /** Consecutive drift-rejects that force a reset. Primary release rule. */
   maxConsecutiveDriftRejects?: number;
-  /** Milliseconds without an accepted detection before the lock expires. */
+  /**
+   * Milliseconds without an accepted detection before the lock expires.
+   *
+   * COUPLED CONSTANT — this must exceed one full detection cycle, which is
+   * `MIN_DETECT_INTERVAL_MS` (CameraViewfinder, 80ms) plus however long
+   * `Detector.detect()` takes. Detection is capped at `DETECTION_MAX_EDGE`
+   * (detection-size.ts) to keep that true; a fraction-of-video sizing let the
+   * 4K camera raise push detect latency past this bound, and the box went
+   * jumpy on-device with no error anywhere. Raise one, check the other.
+   *
+   * Same shape as the TARGET_DPI / page_render_dpi pair in CLAUDE.md Gotchas:
+   * two numbers that must stay in a relationship, enforced only by this note.
+   *
+   * Note what breaching it does NOT do. `reset()` empties `buffer`, so the very
+   * next `push` sees `buffer.length (0) >= warmupFrames` as false and accepts
+   * unconditionally — the box returns within one cycle. A slow detector makes
+   * the box JUMPY, never sustainedly absent. Sustained absence means
+   * `corners: null` repeatedly, which is a detector or hard-reject problem and
+   * no amount of tuning here will touch it.
+   */
   staleMs?: number;
 }
 

--- a/frontend/src/lib/scanner/test-frame-upload.ts
+++ b/frontend/src/lib/scanner/test-frame-upload.ts
@@ -2,7 +2,12 @@ import { api } from "@/lib/api";
 import type { Quad } from "./detector";
 import { normalizeQuad } from "./geometry";
 
-const LONG_EDGE = 1280;
+/**
+ * The corpus's stored resolution. Exported because `ScannerLabPage` uploads into
+ * the same corpus and must not store a different size; it used to keep its own
+ * copy of this number, coupled only by a comment.
+ */
+export const LONG_EDGE = 1280;
 const JPEG_QUALITY = 0.85;
 
 /**

--- a/frontend/src/pages/ScannerLabPage.tsx
+++ b/frontend/src/pages/ScannerLabPage.tsx
@@ -5,10 +5,11 @@ import { initScanner } from "@/lib/opencv-loader";
 import { ClassicalDetector, CLASSICAL_DEFAULTS, type ClassicalParams } from "@/lib/scanner/classical-detector";
 import { MLDetector, ML_DEFAULTS, type MLParams } from "@/lib/scanner/ml-detector";
 import type { Detector, DetectionOutcome, DetectionResult, Quad } from "@/lib/scanner/detector";
-import { REJECT_OUTCOMES } from "@/lib/scanner/detector";
-import { quadIoU, normalizeQuad, orderQuadByAngle, scaleQuad } from "@/lib/scanner/geometry";
+import { isRejectOutcome } from "@/lib/scanner/detector";
+import { quadIoU, normalizeQuad, orderQuadByAngle, quadsEqual, scaleDetectionResult } from "@/lib/scanner/geometry";
 import { downscaleImageData, imageDataToCanvas } from "@/lib/scanner/canvas-utils";
 import { DETECTION_MAX_EDGE } from "@/lib/scanner/detection-size";
+import { LONG_EDGE } from "@/lib/scanner/test-frame-upload";
 
 /**
  * The Lab preview deliberately does NOT take the scanner's 4K raise.
@@ -34,12 +35,13 @@ const LAB_PREVIEW_WIDTH = 1920;
 const LAB_PREVIEW_HEIGHT = 1080;
 
 /**
- * Match `test-frame-upload.ts` — the corpus stores 1280px-long-edge JPEGs at
- * q0.85. Lab captures used to upload at full resolution and q0.9, which is both
- * a multi-megabyte upload (worse at 4K) and a corpus that mixes resolutions the
- * eval then can't compare across.
+ * Imported from `test-frame-upload.ts` rather than restated: both paths write
+ * into the same corpus, and two numbers coupled only by a comment is how a
+ * corpus ends up mixing resolutions the eval cannot compare across. Lab captures
+ * used to upload at full resolution and q0.9, which was also a multi-megabyte
+ * upload at 4K.
  */
-const UPLOAD_LONG_EDGE = 1280;
+const UPLOAD_LONG_EDGE = LONG_EDGE;
 const UPLOAD_JPEG_QUALITY = 0.85;
 
 interface LoadedFrame {
@@ -257,7 +259,7 @@ export default function ScannerLabPage() {
       // rejected quad and an empty frame both score 0 IoU, so the median alone
       // can never tell a too-tight threshold from a blind scanner.
       if (!result.corners) {
-        if (result.outcome && REJECT_OUTCOMES.includes(result.outcome)) {
+        if (isRejectOutcome(result.outcome)) {
           rejects[result.outcome] = (rejects[result.outcome] ?? 0) + 1;
         } else {
           misses++;
@@ -535,7 +537,11 @@ function DetectorPanel({
     const result = panel.result;
     if (result?.candidates) {
       for (const c of result.candidates) {
-        if (c.quad === result.corners) continue;
+        // Compare by VALUE, not by object identity. The accepted quad is drawn
+        // solid below; without this it would also draw here as a faint
+        // candidate underneath itself. Identity used to answer this, and broke
+        // silently the first time a transform mapped over the result.
+        if (result.corners && quadsEqual(c.quad, result.corners)) continue;
         drawQuad(ctx, c.quad, sx, sy, color, 1, false, 0.3);
       }
     }
@@ -597,7 +603,9 @@ function DetectorPanel({
         </div>
       )}
 
-      {panel.evalReport && (
+      {panel.evalReport && (() => {
+        const rejectCount = sumValues(panel.evalReport.rejects);
+        return (
         <div className="text-xs grid grid-cols-2 gap-2 bg-muted/50 p-3 rounded-md">
           <span>Eval on {panel.evalReport.count} annotated frames</span>
           <span>Hit rate: <strong>{(panel.evalReport.hitRate * 100).toFixed(0)}%</strong></span>
@@ -617,9 +625,9 @@ function DetectorPanel({
             No corners: <strong>{panel.evalReport.misses}</strong> scanner miss
             {panel.evalReport.misses === 1 ? "" : "es"}
             {", "}
-            <strong>{sumValues(panel.evalReport.rejects)}</strong> hard reject
-            {sumValues(panel.evalReport.rejects) === 1 ? "" : "s"}
-            {sumValues(panel.evalReport.rejects) > 0 && (
+            <strong>{rejectCount}</strong> hard reject
+            {rejectCount === 1 ? "" : "s"}
+            {rejectCount > 0 && (
               <span className="text-muted-foreground">
                 {" ("}
                 {Object.entries(panel.evalReport.rejects)
@@ -639,7 +647,8 @@ function DetectorPanel({
             <span className="text-[#ba1a1a]">{panel.evalReport.unparsed} unparsable ground truth</span>
           )}
         </div>
-      )}
+        );
+      })()}
 
       <div className="flex gap-2">
         <button onClick={onDetect} className="flex-1 py-2 rounded-lg bg-primary text-primary-foreground font-bold text-sm">
@@ -873,26 +882,7 @@ async function detectAtRuntimeSize(
 ): Promise<DetectionResult> {
   const { data, scale } = downscaleImageData(image, DETECTION_MAX_EDGE);
   const result = await det.detect(data, params);
-  if (scale === 1) return result;
-  const k = 1 / scale;
-  const corners = result.corners ? scaleQuad(result.corners, k) : null;
-  return {
-    ...result,
-    corners,
-    // `candidates` carries the REJECTED quad, which is the whole point of the
-    // reject breakdown. Leaving it in downscaled space would put a landmine
-    // under the first caller that draws it.
-    //
-    // The identity reuse is load-bearing, not a micro-optimisation: the Lab
-    // overlay skips the candidate that IS the accepted quad by reference
-    // (`c.quad === result.corners`), so scaling them into two separate objects
-    // would draw the accepted quad twice, once faint and once solid. A rejected
-    // quad has `corners: null`, so it correctly stays a lone faint outline —
-    // which is how a near-miss is meant to look.
-    candidates: result.candidates?.map((c) =>
-      c.quad === result.corners && corners ? { ...c, quad: corners } : { ...c, quad: scaleQuad(c.quad, k) },
-    ),
-  };
+  return scaleDetectionResult(result, 1 / scale);
 }
 
 async function fetchImageData(url: string): Promise<ImageData> {

--- a/frontend/src/pages/ScannerLabPage.tsx
+++ b/frontend/src/pages/ScannerLabPage.tsx
@@ -4,19 +4,28 @@ import { useCamera } from "@/lib/useCamera";
 import { initScanner } from "@/lib/opencv-loader";
 import { ClassicalDetector, CLASSICAL_DEFAULTS, type ClassicalParams } from "@/lib/scanner/classical-detector";
 import { MLDetector, ML_DEFAULTS, type MLParams } from "@/lib/scanner/ml-detector";
-import type { Detector, DetectionResult, Quad } from "@/lib/scanner/detector";
-import { quadIoU, normalizeQuad, orderQuadByAngle } from "@/lib/scanner/geometry";
+import type { Detector, DetectionOutcome, DetectionResult, Quad } from "@/lib/scanner/detector";
+import { REJECT_OUTCOMES } from "@/lib/scanner/detector";
+import { quadIoU, normalizeQuad, orderQuadByAngle, scaleQuad } from "@/lib/scanner/geometry";
 import { downscaleImageData, imageDataToCanvas } from "@/lib/scanner/canvas-utils";
+import { DETECTION_MAX_EDGE } from "@/lib/scanner/detection-size";
 
 /**
  * The Lab preview deliberately does NOT take the scanner's 4K raise.
  *
  * Every frame the Lab captures is re-encoded to a 1280px long edge on upload
- * (see `imageDataToJpegBlob`), and every frame it evaluates is downscaled again
- * by the detector. A 4K stream here would buy nothing but a 33MB ImageData held
- * in `loaded` state on a phone that the design doc already flags for memory
- * pressure. The scanner, which keeps full resolution for the final extract,
- * gets the raise; the Lab does not.
+ * (see `imageDataToJpegBlob`). A 4K stream here would buy nothing but a 33MB
+ * ImageData held in `loaded` state on a phone that the design doc already flags
+ * for memory pressure. The scanner, which keeps full resolution for the final
+ * extract, gets the raise; the Lab does not.
+ *
+ * CORRECTION (2026-09-05): this comment used to also claim "every frame it
+ * evaluates is downscaled again by the detector". Nothing downscaled anything —
+ * `fetchImageData` sizes its canvas from `img.naturalWidth` and hands the
+ * detector the stored 1280px frame whole. So the Lab was measuring a resolution
+ * production never runs at, and any threshold tuned here did not transfer to the
+ * phone. `runDetect` and `runEval` now downscale to `DETECTION_MAX_EDGE`
+ * explicitly, and the eval report states the edge it used.
  *
  * The negotiated resolution is still surfaced under the viewfinder, so the
  * device's actual capability can be read off on-device without a debugger.
@@ -67,6 +76,23 @@ interface EvalReport {
   errors: number;
   /** Frames skipped because their stored ground truth would not parse. */
   unparsed: number;
+  /**
+   * The longest edge every frame was downscaled to before detection. Stamped on
+   * the report because the corpus stores 1280px frames while the detector is
+   * tuned for ~800: without this number an eval result cannot be compared
+   * against another one taken at a different edge, which is exactly how the
+   * pre-2026-09-05 numbers became uninterpretable.
+   */
+  detectionEdge: number;
+  /**
+   * The `corners: null` breakdown — the measurement this whole Lab pass exists
+   * for. `misses` is "the scanner looked and found nothing"; `rejects` is "the
+   * scanner found a quad and our own geometry gates threw it away", keyed by
+   * which gate fired. They call for opposite fixes and used to be
+   * indistinguishable.
+   */
+  misses: number;
+  rejects: Partial<Record<DetectionOutcome, number>>;
 }
 
 const PALETTE_A = "#006d37";
@@ -171,8 +197,7 @@ export default function ScannerLabPage() {
     if (!loaded || !scannerReady) return;
     const det = detectorFor(panel.kind);
     const params = panel.kind === "ml" ? panel.ml : panel.classical;
-    const result = await det.detect(loaded.imageData, params);
-    set({ ...panel, result });
+    set({ ...panel, result: await detectAtRuntimeSize(det, loaded.imageData, params) });
   }, [loaded, scannerReady, detectorFor]);
 
   const saveGroundTruth = useCallback(async () => {
@@ -208,6 +233,8 @@ export default function ScannerLabPage() {
     let hits = 0;
     let errors = 0;
     let unparsed = 0;
+    let misses = 0;
+    const rejects: Partial<Record<DetectionOutcome, number>> = {};
     for (const f of annotated) {
       let gt: Quad;
       try {
@@ -217,7 +244,7 @@ export default function ScannerLabPage() {
         continue;
       }
       const imageData = await fetchImageData(api.scannerTestFrameImageUrl(f.id));
-      const result = await det.detect(imageData, params);
+      const result = await detectAtRuntimeSize(det, imageData, params);
       if (result.error) {
         // The detector broke; it did not look at this frame and miss. Scoring
         // it 0 would corrupt the median with a number that says nothing about
@@ -226,6 +253,16 @@ export default function ScannerLabPage() {
         continue;
       }
       timings.push(result.timingMs);
+      // Tally WHY a frame produced nothing, before it is scored 0 below. A
+      // rejected quad and an empty frame both score 0 IoU, so the median alone
+      // can never tell a too-tight threshold from a blind scanner.
+      if (!result.corners) {
+        if (result.outcome && REJECT_OUTCOMES.includes(result.outcome)) {
+          rejects[result.outcome] = (rejects[result.outcome] ?? 0) + 1;
+        } else {
+          misses++;
+        }
+      }
       // Order BOTH quads before measuring. quadIoU's polygonClip defines
       // "inside" as isLeft >= 0, so a quad wound the other way yields an empty
       // intersection and IoU 0 -- which reads as "the detector missed", the
@@ -253,6 +290,9 @@ export default function ScannerLabPage() {
       medianTimingMs: median(timings),
       errors,
       unparsed,
+      detectionEdge: DETECTION_MAX_EDGE,
+      misses,
+      rejects,
     };
     set({ ...panel, evalReport: report });
   }, [frames, detectorFor]);
@@ -563,6 +603,33 @@ function DetectorPanel({
           <span>Hit rate: <strong>{(panel.evalReport.hitRate * 100).toFixed(0)}%</strong></span>
           <span>Median IoU: <strong>{panel.evalReport.medianIoU.toFixed(3)}</strong></span>
           <span>Median time: <strong>{panel.evalReport.medianTimingMs.toFixed(0)} ms</strong></span>
+          <span className="col-span-2 text-muted-foreground">
+            Detected at <strong>{panel.evalReport.detectionEdge}px</strong> long edge — only
+            comparable against other runs at the same edge.
+          </span>
+          {/*
+            The measurement this panel exists for: of the frames that produced
+            no corners, how many did the scanner never see a document in, versus
+            how many did it see one and our own gates discard. Tuning thresholds
+            can only ever fix the second.
+          */}
+          <span className="col-span-2">
+            No corners: <strong>{panel.evalReport.misses}</strong> scanner miss
+            {panel.evalReport.misses === 1 ? "" : "es"}
+            {", "}
+            <strong>{sumValues(panel.evalReport.rejects)}</strong> hard reject
+            {sumValues(panel.evalReport.rejects) === 1 ? "" : "s"}
+            {sumValues(panel.evalReport.rejects) > 0 && (
+              <span className="text-muted-foreground">
+                {" ("}
+                {Object.entries(panel.evalReport.rejects)
+                  .sort((a, b) => b[1] - a[1])
+                  .map(([k, v]) => `${k.replace("rejected-", "")} ${v}`)
+                  .join(", ")}
+                {")"}
+              </span>
+            )}
+          </span>
           {panel.evalReport.errors > 0 && (
             <span className="text-[#ba1a1a] font-bold">
               {panel.evalReport.errors} detector error{panel.evalReport.errors === 1 ? "" : "s"} (excluded -- this number is not a clean baseline)
@@ -601,6 +668,10 @@ function DetectorPanel({
       )}
     </div>
   );
+}
+
+function sumValues(counts: Partial<Record<string, number>>): number {
+  return Object.values(counts).reduce((a: number, b) => a + (b ?? 0), 0);
 }
 
 function Stat({ label, value }: { label: string; value: string }) {
@@ -775,6 +846,53 @@ function GroundTruthAnnotator({ frame, quad, onChange, onSave, canSave }: Annota
       </button>
     </div>
   );
+}
+
+/**
+ * Detect at the resolution the SCANNER runs at, not the one the corpus happens
+ * to be stored at.
+ *
+ * Corpus frames are stored at a 1280px long edge (`UPLOAD_LONG_EDGE`, matching
+ * `test-frame-upload.ts`). The detector is tuned for ~800. Until 2026-09-05 the
+ * Lab handed the stored frame over whole, so every IoU, every timing, and every
+ * threshold tuned against them belonged to a resolution production never runs at
+ * — and nothing said so.
+ *
+ * Corners come back in downscaled space and are scaled back to the source
+ * frame's space here, so every caller keeps working in one space: the loaded
+ * image's. `downscaleImageData` returns the ratio it actually applied and it is
+ * the only ratio used — recomputing it is how coordinate bugs are born.
+ *
+ * Note `scale` is 1 for any frame already within the target, in which case this
+ * is a pass-through with no copy.
+ */
+async function detectAtRuntimeSize(
+  det: Detector,
+  image: ImageData,
+  params: unknown,
+): Promise<DetectionResult> {
+  const { data, scale } = downscaleImageData(image, DETECTION_MAX_EDGE);
+  const result = await det.detect(data, params);
+  if (scale === 1) return result;
+  const k = 1 / scale;
+  const corners = result.corners ? scaleQuad(result.corners, k) : null;
+  return {
+    ...result,
+    corners,
+    // `candidates` carries the REJECTED quad, which is the whole point of the
+    // reject breakdown. Leaving it in downscaled space would put a landmine
+    // under the first caller that draws it.
+    //
+    // The identity reuse is load-bearing, not a micro-optimisation: the Lab
+    // overlay skips the candidate that IS the accepted quad by reference
+    // (`c.quad === result.corners`), so scaling them into two separate objects
+    // would draw the accepted quad twice, once faint and once solid. A rejected
+    // quad has `corners: null`, so it correctly stays a lone faint outline —
+    // which is how a near-miss is meant to look.
+    candidates: result.candidates?.map((c) =>
+      c.quad === result.corners && corners ? { ...c, quad: corners } : { ...c, quad: scaleQuad(c.quad, k) },
+    ),
+  };
 }
 
 async function fetchImageData(url: string): Promise<ImageData> {

--- a/frontend/src/pages/ScannerPage.tsx
+++ b/frontend/src/pages/ScannerPage.tsx
@@ -100,18 +100,11 @@ export default function ScannerPage() {
     return () => { cancelled = true; };
   }, [dispatch, unsupported, insecure, classical, ml]);
 
-  /**
-   * Run the warp for a given crop quad and publish the result.
-   *
-   * `detectionScale: 1` is passed EXPLICITLY. `corners` is in raw-frame pixels
-   * now, and opencv-loader's default of 0.4 would multiply it by 2.5. The
-   * parameter disappears entirely in Increment 2; until then, never rely on its
-   * default. (Task T7.)
-   */
+  /** Run the warp for a given crop quad (raw-frame pixels) and publish it. */
   const runExtract = useCallback(
     async (raw: ImageData, corners: Quad | null, job: number) => {
       try {
-        const result = await extractAndEnhance(raw, corners, 1);
+        const result = await extractAndEnhance(raw, corners);
         if (jobRef.current !== job) return;
         dispatch({ type: "extracted", extracted: result.original, enhanced: result.enhanced });
       } catch (err: any) {

--- a/frontend/src/pages/ScannerPage.tsx
+++ b/frontend/src/pages/ScannerPage.tsx
@@ -10,6 +10,7 @@ import type { ScannerState } from "@/lib/useScanner";
 import type { ScannedPage } from "@/lib/pdf-builder";
 import { ClassicalDetector } from "@/lib/scanner/classical-detector";
 import { MLDetector } from "@/lib/scanner/ml-detector";
+import { DETECTION_MAX_EDGE } from "@/lib/scanner/detection-size";
 import type { Detector, Quad } from "@/lib/scanner/detector";
 import {
   canvasToJpegBlob,
@@ -37,9 +38,10 @@ interface ActiveConfig {
  * a 240px canvas blur over 2Mpx plus ~8Mpx of per-pixel JS loops, synchronously,
  * on the shutter tap. That is exactly the shutter-latency regression that killed
  * PR #8 (success criterion 6). At ~800px the fresh detect costs about the same
- * as one live-loop detection.
+ * as one live-loop detection — which is why this is not an independent number
+ * but an alias for the shared one. See `detection-size.ts`.
  */
-const REVIEW_DETECT_MAX_EDGE = 800;
+const REVIEW_DETECT_MAX_EDGE = DETECTION_MAX_EDGE;
 
 export default function ScannerPage() {
   const navigate = useNavigate();


### PR DESCRIPTION
Stacked on #34. Base is `fix/scanner-detection-and-capture`, so this PR shows only its own 15 files; it reaches master when #34 does.

## The problem

`CameraViewfinder` sized its detection frame as a *fraction* of the video (`videoWidth * 0.4`), tuned when the preview was 1080p: 0.4 × 1920 = 768px, matching the ~800px contract in `detector.ts`. Commit 3ebd0f1 raised the camera ladder to 3840×2160 and silently made that **1536px — 4× the pixels every `ClassicalParams` default was tuned against.** Scanic discards everything above 800 itself (`maxProcessingDimension`), so the extra pixels only ever cost `preprocess()` five per-pixel JS passes.

## Measured before changing anything

A diagnostics strip and a `REQ 4K` / `REQ 1080p` toggle were added first, so the two arms could be compared against the same receipt in the same light rather than across two builds.

On-device (Galaxy S26 Ultra):
- **Same `deviceId` in both arms** — the 4K rung is not selecting a different lens, and `granted` matched the decoded `video` size, so no orientation mismatch either. Both hypotheses dead.
- **The box is measurably more stable at 1080p**, where detection runs at 768px.

A fixed edge gives the scanner that stability while `handleCapture` still grabs the full video frame, so the extract keeps every 4K pixel — which capping the camera would have thrown away.

## What this is not

An earlier reading blamed slow detection for the box being *absent*. Tracing `smoother.ts` killed that: `reset()` empties `buffer`, so the next `push` sees `buffer.length (0) >= warmupFrames` as false and accepts unconditionally. Neither the `staleMs` expiry nor the drift-reject rule can hide the box for more than one cycle. Slow detection makes it **jumpy, never sustainedly absent** — which is why the instrumentation below exists to find what does.

And this is **not** "same detection, only cheaper". `preprocess` now runs at 800 and hands scanic an 800px canvas; before it ran at 1536 and scanic resampled the already-normalised result down. Different images, and a 192px blur at 1536 is not the same operator as a 100px blur at 800. Direction unknown; the Lab eval is what would show it.

## Also in here

- **`DetectionOutcome`** splits `corners: null` into its causes. A scanic miss and a hard reject were both null-with-no-error, which the viewfinder renders identically — and they call for opposite fixes. The Lab now reports the breakdown.
- **The Lab was measuring a resolution production never runs at.** `fetchImageData` sized its canvas from `img.naturalWidth` with no downscale, so eval ran at the corpus's 1280px. Any threshold tuned there did not transfer to the phone. The header comment claiming otherwise was false and is corrected.
- **The last surviving `0.4`**: `opencv-loader` still defaulted `detectionScale = 0.4`; `detectCorners` had no call sites; the one `extractAndEnhance` caller passed `1` explicitly plus nine lines of comment guarding against the default. All deleted.

## Review

`/plan-eng-review` restructured the plan from ship-the-fix to measure-then-fix after an outside voice showed the causal chain didn't hold. `/review` then ran four specialist lenses and found **two real bugs in the first commit's own code**:

- `detectionSizeFor(1920, 0)` returned `{w: 800, h: 1}` — the guard tested the longest edge, so a zero height passed it and a `Math.max(1, …)` floor invented a dimension. The test written for that exact case asserted only `.not.toBeNaN()`, true of the fabricated value, so it passed while the bug was live.
- `detectionSizeFor(Infinity, 1080)` returned `scale: 0`, which becomes `Infinity` at every `1 / scale` call site. Found by the test written for the first bug.

Plus: `REJECT_OUTCOMES` made compiler-exhaustive (the loose spelling accepted any subset, so a new reject would tally as "the scanner saw nothing"); a `NaN` sweep in `firstHardReject` (every gate is `x < t`, all NaN comparisons are false, so a NaN metric passed all four as *accepted*); and object-identity dedupe in the Lab overlay replaced with value comparison after this diff demonstrated exactly how it breaks.

## Verification

- 183 tests (was 141 on the base), typecheck clean, build clean
- Zero lint errors on any line this branch touches, verified by cross-referencing eslint output against the diff's changed lines
- On-device: E1 and E2 above. E3/E4 (Lab miss-vs-reject split, and whether `preprocess` earns its keep at all) still to run

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011vnW7xgP7MyvmvdrbQYzrL